### PR TITLE
Increases buffer size to account for terminating NULL.

### DIFF
--- a/src/glfont.cpp
+++ b/src/glfont.cpp
@@ -331,7 +331,8 @@ bool GlFont::LoadFontFromFile( const std::string& filename )
 
 bool GlFont::LoadEmbeddedFont()
 {
-    char* str = new char[font_xml_data.size()];
+    // Include an extra byte for the terminating NULL
+    char* str = new char[font_xml_data.size() + 1];
     strcpy( str, font_xml_data.c_str() );
     const bool success = LoadFontFromText(str);
     delete[] str;


### PR DESCRIPTION
Vaglrind found an invalid write here. string::size() returns the number of characters in a string, but strcpy copies that plus the null terminating byte, resulting in a buffer overrun of 1 byte.
