### PR TITLE
fixes for OpenNI 1.x depth&rgb reg/sync

### DIFF
--- a/include/pangolin/gl/glcuda.h
+++ b/include/pangolin/gl/glcuda.h
@@ -168,7 +168,7 @@ inline GlTextureCudaArray::~GlTextureCudaArray()
     }
 }
 
-void GlTextureCudaArray::Reinitialise(int width, int height, GLint internal_format, bool sampling_linear)
+inline void GlTextureCudaArray::Reinitialise(int width, int height, GLint internal_format, bool sampling_linear)
 {
     if(cuda_res) {
         cudaGraphicsUnregisterResource(cuda_res);


### PR DESCRIPTION
Simultaneous Rgb and Depth was broken with OpenNI 1.x. Only depth channel was readable. Rgb node had to be configured after depth. Also FrameSync is now enabled. 