### PR TITLE
Bugfix: GrabNewest now calls GrabNewest instead of GrabNext

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -527,7 +527,7 @@ bool VideoInput::GrabNext( unsigned char* image, bool wait )
 bool VideoInput::GrabNewest( unsigned char* image, bool wait )
 {
     if( !video ) throw VideoException("No video source open");
-    return video->GrabNext(image,wait);
+    return video->GrabNewest(image,wait);
 }
 
 bool VideoInput::Grab( unsigned char* buffer, std::vector<Image<unsigned char> >& images, bool wait, bool newest)


### PR DESCRIPTION
I couldn't understand why my video stream was lagging when my main loop was running below frame-rate - this seems to be the reason.