### PR TITLE
Fix linkage of AnonymousPro_ttf

### DIFF
--- a/src/gl/glfont.cpp
+++ b/src/gl/glfont.cpp
@@ -40,7 +40,7 @@
 #define MAX_TEXT_LENGTH 500
 
 // Embedded fonts:
-extern const unsigned char AnonymousPro_ttf[];
+extern "C" const unsigned char AnonymousPro_ttf[];
 
 namespace pangolin
 {


### PR DESCRIPTION
The linkage of this symbol doesn't work when building in MSVC since the font is embedded in fonts.c rather than fonts.cpp