### PR TITLE
Include <vector> in common header file.

### DIFF
--- a/include/pangolin/image/image_common.h
+++ b/include/pangolin/image/image_common.h
@@ -34,6 +34,7 @@
 #include <exception>
 #include <string>
 #include <map>
+#include <vector>
 
 namespace pangolin
 {

--- a/src/image/image_common.cpp
+++ b/src/image/image_common.cpp
@@ -28,8 +28,6 @@
 #include <pangolin/image/image_common.h>
 #include <pangolin/utils/file_utils.h>
 
-#include <vector>
-
 namespace pangolin
 {
 


### PR DESCRIPTION
Including `<vector>` in a source file versus a common header was causing a build failure with `src/image/image_io.cpp` since commit d431d5f0b30106f249b76a51d84018c0ef3648a5.