### PR TITLE
Address join sync lag.

### DIFF
--- a/include/pangolin/video/drivers/pleora.h
+++ b/include/pangolin/video/drivers/pleora.h
@@ -54,7 +54,9 @@ class PANGOLIN_EXPORT PleoraVideo :
 {
 public:
 
-    PleoraVideo(const char *model_name, const char *serial_num, size_t index, size_t bpp = 8, size_t binX = 1, size_t binY = 1, size_t buffer_count = 4,
+    static const size_t DEFAULT_BUFFER_COUNT = 30;
+
+    PleoraVideo(const char *model_name, const char *serial_num, size_t index, size_t bpp = 8, size_t binX = 1, size_t binY = 1, size_t buffer_count = DEFAULT_BUFFER_COUNT,
                 size_t desired_size_x = 0, size_t desired_size_y = 0, size_t desired_pos_x = 0, size_t desired_pos_y = 0, int again = -1, double exposure = 0,
                 bool ext_trig=false);
     ~PleoraVideo();

--- a/src/video/drivers/join.cpp
+++ b/src/video/drivers/join.cpp
@@ -152,7 +152,7 @@ bool VideoJoiner::GrabNewest( unsigned char* image, bool wait )
   int64_t oldest = std::numeric_limits<int64_t>::max();
   bool grabbed_any = false;
   int first_stream_backlog = 0;
-  int64_t rt;
+  int64_t rt = 0;
 
   bool got_frame = false;
   do {
@@ -171,11 +171,13 @@ bool VideoJoiner::GrabNewest( unsigned char* image, bool wait )
           grabbed_any = true;
       }
   } while(got_frame);
-  reception_times.push_back(rt);
-  if(newest < rt) newest = rt;
-  if(oldest > rt) oldest = rt;
   offsets.push_back(offset);
   offset += src[0]->SizeBytes();
+  if(sync_attempts_to_go >= 0) {
+      reception_times.push_back(rt);
+      if(newest < rt) newest = rt;
+      if(oldest > rt) oldest = rt;
+  }
 
   for(size_t s=1; s<src.size(); ++s) {
       for (int i=0; i<first_stream_backlog; i++){
@@ -190,11 +192,13 @@ bool VideoJoiner::GrabNewest( unsigned char* image, bool wait )
               }
           }
       }
-      reception_times.push_back(rt);
-      if(newest < rt) newest = rt;
-      if(oldest > rt) oldest = rt;
       offsets.push_back(offset);
       offset += src[s]->SizeBytes();
+      if(sync_attempts_to_go >= 0) {
+          reception_times.push_back(rt);
+          if(newest < rt) newest = rt;
+          if(oldest > rt) oldest = rt;
+      }
   }
 
   if((sync_continuously || (sync_attempts_to_go == 0)) && ((newest - oldest) > sync_tolerance_us) ){

--- a/src/video/drivers/join.cpp
+++ b/src/video/drivers/join.cpp
@@ -135,12 +135,83 @@ bool VideoJoiner::GrabNext( unsigned char* image, bool wait )
        if(!sync_continuously) --sync_attempts_to_go;
     }
 
+    std::cout<<sync_continuously<<" "<<oldest<<" "<<newest<<" "<<(newest - oldest)<<std::endl;
     return grabbed_any;
 }
 
 bool VideoJoiner::GrabNewest( unsigned char* image, bool wait )
 {
-    return GrabNext(image, wait);
+  // Simply calling GrabNewest on the child streams might cause loss of sync,
+  // instead we perform as many GrabNext as possible on the first stream and
+  // then pull the same number of frames from every other stream.
+
+  size_t offset = 0;
+  std::vector<size_t> offsets;
+  std::vector<int64_t> reception_times;
+  int64_t newest = std::numeric_limits<int64_t>::min();
+  int64_t oldest = std::numeric_limits<int64_t>::max();
+  bool grabbed_any = false;
+  int first_stream_backlog = 0;
+  int64_t rt;
+
+  bool got_frame = false;
+  do {
+      got_frame = src[0]->GrabNext(image+offset,false);
+      if(got_frame) {
+          if(sync_attempts_to_go >= 0) {
+              VideoPropertiesInterface* vidpi = dynamic_cast<VideoPropertiesInterface*>(src[0]);
+              if(vidpi->FrameProperties().contains(PANGO_HOST_RECEPTION_TIME_US)) {
+                  rt = vidpi->FrameProperties()[PANGO_HOST_RECEPTION_TIME_US].get<int64_t>();
+              } else {
+                  sync_attempts_to_go = -1;
+                  pango_print_error("Stream %u in join does not support startup_sync_us option.\n", 0);
+              }
+          }
+          first_stream_backlog++;
+          grabbed_any = true;
+      }
+  } while(got_frame);
+  reception_times.push_back(rt);
+  if(newest < rt) newest = rt;
+  if(oldest > rt) oldest = rt;
+  offsets.push_back(offset);
+  offset += src[0]->SizeBytes();
+
+  for(size_t s=1; s<src.size(); ++s) {
+      for (int i=0; i<first_stream_backlog; i++){
+          grabbed_any |= src[s]->GrabNext(image+offset,true);
+          if(sync_attempts_to_go >= 0) {
+              VideoPropertiesInterface* vidpi = dynamic_cast<VideoPropertiesInterface*>(src[s]);
+              if(vidpi->FrameProperties().contains(PANGO_HOST_RECEPTION_TIME_US)) {
+                  rt = vidpi->FrameProperties()[PANGO_HOST_RECEPTION_TIME_US].get<int64_t>();
+              } else {
+                  sync_attempts_to_go = -1;
+                  pango_print_error("Stream %lu in join does not support startup_sync_us option.\n", s);
+              }
+          }
+      }
+      reception_times.push_back(rt);
+      if(newest < rt) newest = rt;
+      if(oldest > rt) oldest = rt;
+      offsets.push_back(offset);
+      offset += src[s]->SizeBytes();
+  }
+
+  if((sync_continuously || (sync_attempts_to_go == 0)) && ((newest - oldest) > sync_tolerance_us) ){
+     pango_print_warn("Join error, unable to sync streams within %lu us\n", sync_tolerance_us);
+  }
+
+  if(sync_attempts_to_go >= 0) {
+     for(size_t s=0; s<src.size(); ++s) {
+        if(reception_times[s] < (newest - sync_tolerance_us)) {
+           VideoInterface& vid = *src[s];
+           vid.GrabNewest(image+offsets[s],false);
+        }
+     }
+     if(!sync_continuously) --sync_attempts_to_go;
+  }
+
+  return grabbed_any;
 }
 
 std::vector<VideoInterface*>& VideoJoiner::InputStreams()

--- a/src/video/drivers/pleora.cpp
+++ b/src/video/drivers/pleora.cpp
@@ -289,13 +289,14 @@ const std::vector<StreamInfo>& PleoraVideo::Streams() const
     return streams;
 }
 
-bool PleoraVideo::GrabNext( unsigned char* image, bool /*wait*/ )
+bool PleoraVideo::GrabNext( unsigned char* image, bool wait)
 {
     PvBuffer *lBuffer = NULL;
     PvResult lOperationResult;
+    const uint32_t timeout = wait ? 1000 : 0;
 
     // Retrieve next buffer
-    PvResult lResult = lStream->RetrieveBuffer( &lBuffer, &lOperationResult, 1000 );
+    PvResult lResult = lStream->RetrieveBuffer( &lBuffer, &lOperationResult, timeout);
     if ( !lResult.IsOK() ) {
         pango_print_warn("Pleora error: %s,\n'%s'\n", lResult.GetCodeString().GetAscii(), lResult.GetDescription().GetAscii() );
         return false;
@@ -327,7 +328,6 @@ bool PleoraVideo::GrabNewest( unsigned char* image, bool wait )
     PvBuffer *lBuffer0 = NULL;
     PvBuffer *lBuffer = NULL;
     PvResult lOperationResult;
-
     const uint32_t timeout = wait ? 0xFFFFFFFF : 0;
 
     PvResult lResult = lStream->RetrieveBuffer( &lBuffer, &lOperationResult, timeout );

--- a/src/video/drivers/pleora.cpp
+++ b/src/video/drivers/pleora.cpp
@@ -298,7 +298,9 @@ bool PleoraVideo::GrabNext( unsigned char* image, bool wait)
     // Retrieve next buffer
     PvResult lResult = lStream->RetrieveBuffer( &lBuffer, &lOperationResult, timeout);
     if ( !lResult.IsOK() ) {
-        pango_print_warn("Pleora error: %s,\n'%s'\n", lResult.GetCodeString().GetAscii(), lResult.GetDescription().GetAscii() );
+        if(wait || (lResult && !(lResult.GetCode() == PvResult::Code::TIMEOUT))) {
+            pango_print_warn("Pleora error: %s,\n'%s'\n", lResult.GetCodeString().GetAscii(), lResult.GetDescription().GetAscii() );
+        }
         return false;
     }
 
@@ -332,7 +334,9 @@ bool PleoraVideo::GrabNewest( unsigned char* image, bool wait )
 
     PvResult lResult = lStream->RetrieveBuffer( &lBuffer, &lOperationResult, timeout );
     if ( !lResult.IsOK() ) {
-        pango_print_warn("Pleora error: %s,\n'%s'\n", lResult.GetCodeString().GetAscii(), lResult.GetDescription().GetAscii() );
+        if(wait || (lResult && !(lResult.GetCode() == PvResult::Code::TIMEOUT))) {
+            pango_print_warn("Pleora error: %s,\n'%s'\n", lResult.GetCodeString().GetAscii(), lResult.GetDescription().GetAscii() );
+        }
         return false;
     }else if( !lOperationResult.IsOK() ) {
         pango_print_warn("Pleora error: %s,\n'%s'\n", lOperationResult.GetCodeString().GetAscii(), lResult.GetDescription().GetAscii() );

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -671,7 +671,7 @@ VideoInterface* OpenVideo(const Uri& uri)
         const size_t bpp = uri.Get<size_t>("bpp",8);
         const size_t binx = uri.Get<size_t>("binx",1);
         const size_t biny = uri.Get<size_t>("biny",1);
-        const size_t buffer_count = uri.Get<size_t>("buffers",4);
+        const size_t buffer_count = uri.Get<size_t>("buffers", PleoraVideo::DEFAULT_BUFFER_COUNT);
         const ImageDim desired_size = uri.Get<ImageDim>("size", ImageDim(0,0));
         const ImageDim desired_pos  = uri.Get<ImageDim>("pos", ImageDim(0,0));
         const size_t again = uri.Get<size_t>("again",-1);


### PR DESCRIPTION
Patch that adds GrabNewest to join driver; this allows to deal gracefully (and avoid lag) in cases in which join is not called fast enough.