### PR TITLE
Add shared memory buffer video driver

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,3 +34,5 @@ if(BUILD_PANGOLIN_GUI)
 #      endif()
     endif()
 endif()
+
+add_subdirectory(SharedMemoryVideoWriter)

--- a/examples/SharedMemoryVideoWriter/CMakeLists.txt
+++ b/examples/SharedMemoryVideoWriter/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(Pangolin 0.2 REQUIRED)
+include_directories(${Pangolin_INCLUDE_DIRS})
+
+add_executable(SharedMemoryVideoWriter main.cpp)
+target_link_libraries(SharedMemoryVideoWriter ${Pangolin_LIBRARIES})

--- a/examples/SharedMemoryVideoWriter/main.cpp
+++ b/examples/SharedMemoryVideoWriter/main.cpp
@@ -1,0 +1,62 @@
+#include <pangolin/pangolin.h>
+
+#include <pangolin/utils/condition_variable.h>
+#include <pangolin/utils/shared_memory_buffer.h>
+#include <pangolin/utils/timer.h>
+
+#include <cmath>
+#include <cstdint>
+
+// This sample acts as a soft camera. It writes a pattern of GRAY8 pixels to the
+// shared memory space. It can be seen in Pangolin's SimpleVideo sample using
+// the shmem://example?size=640x480 video URI.
+
+using namespace pangolin;
+
+uint8_t generate_value(basetime t, basetime start)
+{
+  int64_t us = TimeDiff_us(start, t);
+
+  // 10s sinusoid
+  double d = 10./(M_PI) * ((double)us/1000000);
+  d = std::sin(d);
+  d = d*128 + 128;
+  return static_cast<uint8_t>(d);
+}
+
+int main(int argc, char *argv[])
+{
+  std::string shmem_name = "/example";
+
+  auto shmem_buffer = create_named_shared_memory_buffer(shmem_name, 640 * 480);
+  if (!shmem_buffer) {
+    perror("Unable to create shared memory buffer");
+    exit(1);
+  }
+
+  auto cond_name = shmem_name + "_cond";
+  auto buffer_full = create_named_condition_variable(cond_name);
+
+  basetime start = TimeNow();
+  basetime d = {0};
+  d.tv_usec = 33333;
+
+  // Sit in a loop and write gray values based on some timing pattern.
+  basetime t = start;
+  while (true) {
+    basetime nt = TimeAdd(t, d);
+
+    shmem_buffer->lock();
+    uint8_t *ptr = shmem_buffer->ptr();
+    uint8_t value = generate_value(t, start);
+
+    for (int i = 0; i < 640*480; ++i) {
+      ptr[i] = value;
+    }
+
+    shmem_buffer->unlock();
+    buffer_full->signal();
+
+    t = WaitUntil(nt);
+  }
+}

--- a/include/pangolin/utils/condition_variable.h
+++ b/include/pangolin/utils/condition_variable.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <pangolin/utils/timer.h>
+
+#include <memory>
+
+namespace pangolin
+{
+
+class ConditionVariableInterface
+{
+public:
+  virtual ~ConditionVariableInterface()
+  {
+  }
+
+  virtual void wait() = 0;
+  virtual bool wait(basetime t) = 0;
+  virtual void signal() = 0;
+  virtual void broadcast() = 0;
+};
+
+std::unique_ptr<ConditionVariableInterface> create_named_condition_variable(const
+  std::string& name);
+std::unique_ptr<ConditionVariableInterface> open_named_condition_variable(const
+  std::string& name);
+}

--- a/include/pangolin/utils/semaphore.h
+++ b/include/pangolin/utils/semaphore.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace pangolin
+{
+
+  class SemaphoreInterface
+  {
+  public:
+
+    virtual ~SemaphoreInterface() {
+    }
+
+    virtual bool tryAcquire() = 0;
+    virtual void acquire() = 0;
+    virtual void release() = 0;
+  };
+
+  std::unique_ptr<SemaphoreInterface> create_named_semaphore(const std::string& name,
+    unsigned int value);
+  std::unique_ptr<SemaphoreInterface> open_named_semaphore(const std::string& name);
+
+}

--- a/include/pangolin/utils/shared_memory_buffer.h
+++ b/include/pangolin/utils/shared_memory_buffer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <pangolin/utils/semaphore.h>
+
+#include <cstdint>
+#include <memory>
+#include <string.h>
+
+namespace pangolin
+{
+  class SharedMemoryBufferInterface
+  {
+  public:
+    virtual ~SharedMemoryBufferInterface() {
+    }
+    virtual bool tryLock() = 0;
+    virtual void lock() = 0;
+    virtual void unlock() = 0;
+    virtual uint8_t *ptr() = 0;
+    virtual std::string name() = 0;
+  };
+
+  std::unique_ptr<SharedMemoryBufferInterface> create_named_shared_memory_buffer(const
+    std::string& name, size_t size);
+  std::unique_ptr<SharedMemoryBufferInterface> open_named_shared_memory_buffer(const
+    std::string& name, bool readwrite);
+}

--- a/include/pangolin/video/drivers/shared_memory.h
+++ b/include/pangolin/video/drivers/shared_memory.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <pangolin/pangolin.h>
+#include <pangolin/video/video.h>
+#include <pangolin/utils/condition_variable.h>
+#include <pangolin/utils/shared_memory_buffer.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace pangolin
+{
+
+class SharedMemoryVideo : public VideoInterface
+{
+public:
+  SharedMemoryVideo(size_t w, size_t h, std::string pix_fmt,
+    std::unique_ptr<SharedMemoryBufferInterface>&& shared_memory,
+    std::unique_ptr<ConditionVariableInterface>&& buffer_full);
+  ~SharedMemoryVideo();
+
+  size_t SizeBytes() const;
+  const std::vector<StreamInfo>& Streams() const;
+  void Start();
+  void Stop();
+  bool GrabNext(unsigned char *image, bool wait);
+  bool GrabNewest(unsigned char *image, bool wait);
+
+private:
+  VideoPixelFormat _fmt;
+  size_t _w;
+  size_t _h;
+  size_t _frame_size;
+  std::vector<StreamInfo> _streams;
+  std::unique_ptr<SharedMemoryBufferInterface> _shared_memory;
+  std::unique_ptr<ConditionVariableInterface> _buffer_full;
+};
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ if(BUILD_PANGOLIN_VIDEO)
     ${INCDIR}/video/drivers/mirror.h
     ${INCDIR}/video/drivers/unpack.h
     ${INCDIR}/video/drivers/join.h
+    ${INCDIR}/video/drivers/shared_memory.h
   )
   list(APPEND SOURCES
     video/drivers/test.cpp
@@ -85,6 +86,7 @@ if(BUILD_PANGOLIN_VIDEO)
     video/drivers/mirror.cpp
     video/drivers/unpack.cpp
     video/drivers/join.cpp
+    video/drivers/shared_memory.cpp
   )
 endif()
 

--- a/src/utils/condition_variable.cpp
+++ b/src/utils/condition_variable.cpp
@@ -1,0 +1,88 @@
+#include <pangolin/utils/condition_variable.h>
+
+#include <pangolin/utils/shared_memory_buffer.h>
+
+#include <pthread.h>
+
+using namespace std;
+
+namespace pangolin {
+
+struct PThreadSharedData {
+  pthread_mutex_t lock;
+  pthread_cond_t cond;
+};
+
+class PThreadConditionVariable : public ConditionVariableInterface {
+public:
+  PThreadConditionVariable(unique_ptr<SharedMemoryBufferInterface> &&shmem)
+      : _shmem(move(shmem)),
+        _pthread_data(reinterpret_cast<PThreadSharedData *>(_shmem->ptr())) {}
+
+  ~PThreadConditionVariable() {}
+
+  void wait() {
+    _lock();
+    pthread_cond_wait(&_pthread_data->cond, &_pthread_data->lock);
+    _unlock();
+  }
+
+  bool wait(basetime abstime) {
+    struct timespec pthread_abstime = {.tv_sec = abstime.tv_sec,
+                                       .tv_nsec = abstime.tv_usec * 1000};
+    _lock();
+    int err = pthread_cond_timedwait(&_pthread_data->cond, &_pthread_data->lock,
+                           &pthread_abstime);
+    _unlock();
+
+    return 0 == err;
+  }
+
+  void signal() { pthread_cond_signal(&_pthread_data->cond); }
+
+  void broadcast() { pthread_cond_broadcast(&_pthread_data->cond); }
+
+private:
+  void _lock() { pthread_mutex_lock(&_pthread_data->lock); }
+
+  void _unlock() { pthread_mutex_unlock(&_pthread_data->lock); }
+
+  unique_ptr<SharedMemoryBufferInterface> _shmem;
+  PThreadSharedData *_pthread_data;
+};
+
+unique_ptr<ConditionVariableInterface>
+create_named_condition_variable(const string &name) {
+  auto shmem =
+      create_named_shared_memory_buffer(name, sizeof(PThreadSharedData));
+  unique_ptr<ConditionVariableInterface> ptr;
+
+  PThreadSharedData *pthread_data =
+      reinterpret_cast<PThreadSharedData *>(shmem->ptr());
+
+  pthread_mutexattr_t mattr;
+  pthread_mutexattr_init(&mattr);
+  pthread_mutexattr_setpshared(&mattr, PTHREAD_PROCESS_SHARED);
+
+  pthread_condattr_t cattr;
+  pthread_condattr_init(&cattr);
+  pthread_condattr_setpshared(&cattr, PTHREAD_PROCESS_SHARED);
+
+  pthread_mutex_init(&pthread_data->lock, &mattr);
+  pthread_cond_init(&pthread_data->cond, &cattr);
+
+  ptr.reset(static_cast<ConditionVariableInterface *>(
+      new PThreadConditionVariable(move(shmem))));
+  return ptr;
+}
+
+unique_ptr<ConditionVariableInterface>
+open_named_condition_variable(const string &name) {
+  auto shmem = open_named_shared_memory_buffer(name, true);
+  unique_ptr<ConditionVariableInterface> ptr;
+
+  ptr.reset(new PThreadConditionVariable(move(shmem)));
+  return ptr;
+}
+
+}

--- a/src/utils/semaphore.cpp
+++ b/src/utils/semaphore.cpp
@@ -1,0 +1,83 @@
+#include <pangolin/utils/semaphore.h>
+
+#include <fcntl.h>
+#include <semaphore.h>
+#include <sys/stat.h>
+
+#include <string>
+
+using namespace std;
+
+namespace pangolin
+{
+
+// TODO(shaheen) register a signal handler for SIGTERM and unlink shared
+// semaphores.
+class PosixSemaphore : public SemaphoreInterface
+{
+public:
+  PosixSemaphore(sem_t *semaphore, bool ownership, const string& name) :
+    _semaphore(semaphore),
+    _ownership(ownership),
+    _name(name)
+  {
+  }
+
+  ~PosixSemaphore()
+  {
+    if (_ownership) {
+      sem_unlink(_name.c_str());
+    } else {
+      sem_close(_semaphore);
+    }
+  }
+
+  bool tryAcquire()
+  {
+    int err = sem_trywait(_semaphore);
+    return err == 0;
+  }
+
+  void acquire()
+  {
+    sem_wait(_semaphore);
+  }
+
+  void release()
+  {
+    sem_post(_semaphore);
+  }
+
+private:
+  sem_t *_semaphore;
+  bool _ownership;
+  string _name;
+};
+
+unique_ptr<SemaphoreInterface> create_named_semaphore(const string& name, unsigned int value)
+{
+  unique_ptr<SemaphoreInterface> ptr;
+  sem_t *semaphore = sem_open(name.c_str(), O_CREAT | O_EXCL,
+    S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP, value);
+  if (NULL == semaphore) {
+    return ptr;
+  }
+
+  ptr.reset(new PosixSemaphore(semaphore, true, name));
+  return ptr;
+}
+
+unique_ptr<SemaphoreInterface> open_named_semaphore(const string& name)
+{
+  unique_ptr<SemaphoreInterface> ptr;
+  sem_t *semaphore = sem_open(name.c_str(), 0);
+
+  if (NULL == semaphore) {
+    return ptr;
+  }
+
+  ptr.reset(new PosixSemaphore(semaphore, false, name));
+  return ptr;
+}
+
+}

--- a/src/utils/shared_memory_buffer.cpp
+++ b/src/utils/shared_memory_buffer.cpp
@@ -1,0 +1,136 @@
+#include <pangolin/utils/shared_memory_buffer.h>
+
+#include <pangolin/utils/semaphore.h>
+
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+using namespace std;
+
+namespace pangolin
+{
+
+// TODO(shaheen) register a signal handler for SIGTERM and unlink shared memory
+// objects.
+class PosixSharedMemoryBuffer : public SharedMemoryBufferInterface
+{
+public:
+  PosixSharedMemoryBuffer(int fd, uint8_t *ptr, size_t size, bool ownership, const std::string& name) :
+    _fd(fd),
+    _ptr(ptr),
+    _size(size),
+    _ownership(ownership),
+    _name(name),
+    _lockCount(0)
+  {
+  }
+
+  ~PosixSharedMemoryBuffer()
+  {
+    close(_fd);
+    munmap(_ptr, _size);
+
+    if (_ownership) {
+      shm_unlink(_name.c_str());
+    }
+  }
+
+  bool tryLock()
+  {
+    if (_lockCount == 0) {
+      int err = flock(_fd, LOCK_EX|LOCK_NB);
+      if (0 == err) {
+        _lockCount++;
+      }
+    }
+    return _lockCount != 0;
+  }
+
+  void lock()
+  {
+    if (_lockCount == 0) {
+      flock(_fd, LOCK_EX);
+    }
+    _lockCount++;
+  }
+
+  void unlock()
+  {
+    if (_lockCount != 0) {
+      flock(_fd, LOCK_UN);
+    }
+    _lockCount--;
+  }
+
+  uint8_t *ptr()
+  {
+    return _ptr;
+  }
+
+  std::string name()
+  {
+    return _name;
+  }
+
+private:
+  int _fd;
+  uint8_t *_ptr;
+  size_t _size;
+  bool _ownership;
+  string _name;
+  unsigned int _lockCount;
+};
+
+unique_ptr<SharedMemoryBufferInterface> create_named_shared_memory_buffer(const
+  string& name, size_t size)
+{
+  unique_ptr<SharedMemoryBufferInterface> ptr;
+
+  int fd = shm_open(name.c_str(), O_RDWR | O_RDONLY | O_CREAT,
+    S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+  if (-1 == fd) {
+    return ptr;
+  }
+
+  int err = ftruncate(fd, size);
+  if (-1 == err) {
+    shm_unlink(name.c_str());
+    return ptr;
+  }
+
+  uint8_t *buffer = reinterpret_cast<uint8_t *>(mmap(NULL, size,
+      PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0));
+
+  ptr.reset(new PosixSharedMemoryBuffer(fd, buffer, size, true, name));
+  return ptr;
+}
+
+unique_ptr<SharedMemoryBufferInterface> open_named_shared_memory_buffer(const
+  string& name, bool readwrite)
+{
+  unique_ptr<SharedMemoryBufferInterface> ptr;
+
+  int fd = shm_open(name.c_str(), readwrite ? O_RDWR | O_RDONLY : O_RDONLY, 0);
+  if (-1 == fd) {
+    return ptr;
+  }
+
+  struct stat sbuf;
+  int err = fstat(fd, &sbuf);
+  if (-1 == err) {
+    return ptr;
+  }
+
+  size_t size = sbuf.st_size;
+  uint8_t *buffer = reinterpret_cast<uint8_t *>(mmap(NULL, size,
+      PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0));
+
+  ptr.reset(new PosixSharedMemoryBuffer(fd, buffer, size, false, name));
+  return ptr;
+}
+
+}

--- a/src/video/drivers/shared_memory.cpp
+++ b/src/video/drivers/shared_memory.cpp
@@ -1,0 +1,64 @@
+#include <pangolin/video/drivers/shared_memory.h>
+
+using namespace std;
+
+namespace pangolin
+{
+
+SharedMemoryVideo::SharedMemoryVideo(size_t w, size_t h, std::string pix_fmt,
+    unique_ptr<SharedMemoryBufferInterface>&& shared_memory,
+    unique_ptr<ConditionVariableInterface>&& buffer_full) :
+    _fmt(VideoFormatFromString(pix_fmt)),
+    _w(w),
+    _h(h),
+    _frame_size(w*h*_fmt.bpp/8),
+    _shared_memory(move(shared_memory)),
+    _buffer_full(move(buffer_full))
+{
+    const StreamInfo stream(_fmt, w, h, _frame_size, 0);
+    _streams.push_back(stream);
+}
+
+SharedMemoryVideo::~SharedMemoryVideo()
+{
+}
+
+void SharedMemoryVideo::Start()
+{
+}
+
+void SharedMemoryVideo::Stop()
+{
+}
+
+size_t SharedMemoryVideo::SizeBytes() const
+{
+    return _frame_size;
+}
+
+const std::vector<StreamInfo>& SharedMemoryVideo::Streams() const
+{
+    return _streams;
+}
+
+bool SharedMemoryVideo::GrabNext(unsigned char* image, bool wait)
+{
+    if (wait) {
+        _buffer_full->wait();
+    } else if (!_buffer_full->wait(TimeNow())) {
+        return false;
+    }
+
+    _shared_memory->lock();
+    memcpy(image, _shared_memory->ptr(), _frame_size);
+    _shared_memory->unlock();
+
+    return true;
+}
+
+bool SharedMemoryVideo::GrabNewest(unsigned char* image, bool wait)
+{
+    return GrabNext(image,wait);
+}
+
+}


### PR DESCRIPTION
These changes add a video driver that sources its data from an external process via a shared memory buffer. The external process writes to the frame buffer and signals a condition variable when the buffer is full. The video driver waits on the condition variable to synchronize the "frame rate" of the external application.
