### PR TITLE
Shared memory video driver

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,3 +34,5 @@ if(BUILD_PANGOLIN_GUI)
 #      endif()
     endif()
 endif()
+
+add_subdirectory(SharedMemoryVideoWriter)

--- a/examples/SharedMemoryVideoWriter/CMakeLists.txt
+++ b/examples/SharedMemoryVideoWriter/CMakeLists.txt
@@ -1,0 +1,7 @@
+if(UNIX)
+find_package(Pangolin 0.2 REQUIRED)
+include_directories(${Pangolin_INCLUDE_DIRS})
+
+add_executable(SharedMemoryVideoWriter main.cpp)
+target_link_libraries(SharedMemoryVideoWriter ${Pangolin_LIBRARIES})
+endif()

--- a/examples/SharedMemoryVideoWriter/main.cpp
+++ b/examples/SharedMemoryVideoWriter/main.cpp
@@ -1,0 +1,64 @@
+#include <pangolin/pangolin.h>
+
+#include <pangolin/compat/memory.h>
+#include <pangolin/utils/posix/condition_variable.h>
+#include <pangolin/utils/posix/shared_memory_buffer.h>
+#include <pangolin/utils/timer.h>
+
+#include <cmath>
+
+// This sample acts as a soft camera. It writes a pattern of GRAY8 pixels to the
+// shared memory space. It can be seen in Pangolin's SimpleVideo sample using
+// the shmem:[size=640x480]//example video URI.
+
+using namespace pangolin;
+
+unsigned char generate_value(basetime t, basetime start)
+{
+  int64_t us = TimeDiff_us(start, t);
+
+  // 10s sinusoid
+  double d = 10./(M_PI) * ((double)us/1000000);
+  d = std::sin(d);
+  d = d*128 + 128;
+  return static_cast<unsigned char>(d);
+}
+
+int main(int argc, char *argv[])
+{
+  std::string shmem_name = "/example";
+
+  boostd::shared_ptr<SharedMemoryBufferInterface> shmem_buffer =
+    create_named_shared_memory_buffer(shmem_name, 640 * 480);
+  if (!shmem_buffer) {
+    perror("Unable to create shared memory buffer");
+    exit(1);
+  }
+
+  std::string cond_name = shmem_name + "_cond";
+  boostd::shared_ptr<ConditionVariableInterface> buffer_full =
+    create_named_condition_variable(cond_name);
+
+  basetime start = TimeNow();
+  basetime d = {0};
+  d.tv_usec = 33333;
+
+  // Sit in a loop and write gray values based on some timing pattern.
+  basetime t = start;
+  while (true) {
+    basetime nt = TimeAdd(t, d);
+
+    shmem_buffer->lock();
+    unsigned char *ptr = shmem_buffer->ptr();
+    unsigned char value = generate_value(t, start);
+
+    for (int i = 0; i < 640*480; ++i) {
+      ptr[i] = value;
+    }
+
+    shmem_buffer->unlock();
+    buffer_full->signal();
+
+    t = WaitUntil(nt);
+  }
+}

--- a/include/pangolin/utils/posix/condition_variable.h
+++ b/include/pangolin/utils/posix/condition_variable.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <pangolin/compat/memory.h>
+#include <pangolin/utils/timer.h>
+
+namespace pangolin
+{
+
+class ConditionVariableInterface
+{
+public:
+  virtual ~ConditionVariableInterface()
+  {
+  }
+
+  virtual void wait() = 0;
+  virtual bool wait(basetime t) = 0;
+  virtual void signal() = 0;
+  virtual void broadcast() = 0;
+};
+
+boostd::shared_ptr<ConditionVariableInterface> create_named_condition_variable(const
+  std::string& name);
+boostd::shared_ptr<ConditionVariableInterface> open_named_condition_variable(const
+  std::string& name);
+}

--- a/include/pangolin/utils/posix/semaphore.h
+++ b/include/pangolin/utils/posix/semaphore.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <pangolin/compat/memory.h>
+
+#include <string>
+
+namespace pangolin
+{
+
+  class SemaphoreInterface
+  {
+  public:
+
+    virtual ~SemaphoreInterface() {
+    }
+
+    virtual bool tryAcquire() = 0;
+    virtual void acquire() = 0;
+    virtual void release() = 0;
+  };
+
+  boostd::shared_ptr<SemaphoreInterface> create_named_semaphore(const std::string& name,
+    unsigned int value);
+  boostd::shared_ptr<SemaphoreInterface> open_named_semaphore(const std::string& name);
+
+}

--- a/include/pangolin/utils/posix/shared_memory_buffer.h
+++ b/include/pangolin/utils/posix/shared_memory_buffer.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <pangolin/compat/memory.h>
+
+#include <string.h>
+
+namespace pangolin
+{
+  class SharedMemoryBufferInterface
+  {
+  public:
+    virtual ~SharedMemoryBufferInterface() {
+    }
+    virtual bool tryLock() = 0;
+    virtual void lock() = 0;
+    virtual void unlock() = 0;
+    virtual unsigned char *ptr() = 0;
+    virtual std::string name() = 0;
+  };
+
+  boostd::shared_ptr<SharedMemoryBufferInterface> create_named_shared_memory_buffer(const
+    std::string& name, size_t size);
+  boostd::shared_ptr<SharedMemoryBufferInterface> open_named_shared_memory_buffer(const
+    std::string& name, bool readwrite);
+}

--- a/include/pangolin/video/drivers/shared_memory.h
+++ b/include/pangolin/video/drivers/shared_memory.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <pangolin/pangolin.h>
+#include <pangolin/compat/memory.h>
+#include <pangolin/video/video.h>
+#include <pangolin/utils/posix/condition_variable.h>
+#include <pangolin/utils/posix/shared_memory_buffer.h>
+
+#include <vector>
+
+namespace pangolin
+{
+
+class SharedMemoryVideo : public VideoInterface
+{
+public:
+  SharedMemoryVideo(size_t w, size_t h, std::string pix_fmt,
+    const boostd::shared_ptr<SharedMemoryBufferInterface>& shared_memory,
+    const boostd::shared_ptr<ConditionVariableInterface>& buffer_full);
+  ~SharedMemoryVideo();
+
+  size_t SizeBytes() const;
+  const std::vector<StreamInfo>& Streams() const;
+  void Start();
+  void Stop();
+  bool GrabNext(unsigned char *image, bool wait);
+  bool GrabNewest(unsigned char *image, bool wait);
+
+private:
+  VideoPixelFormat _fmt;
+  size_t _w;
+  size_t _h;
+  size_t _frame_size;
+  std::vector<StreamInfo> _streams;
+  boostd::shared_ptr<SharedMemoryBufferInterface> _shared_memory;
+  boostd::shared_ptr<ConditionVariableInterface> _buffer_full;
+};
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,12 @@ if(BUILD_PANGOLIN_VIDEO)
     video/drivers/unpack.cpp
     video/drivers/join.cpp
   )
+
+if(UNIX)
+  list(APPEND HEADERS ${INCDIR}/video/drivers/shared_memory.h)
+  list(APPEND SOURCES video/drivers/shared_memory.cpp)
+endif()
+
 endif()
 
 #######################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,6 +198,11 @@ else()
     endif()
 endif()
 
+if(UNIX)
+  append_glob(HEADERS ${INCDIR}/utils/posix/*.h*)
+  append_glob(SOURCES utils/posix/*.cpp)
+endif()
+
 find_package(PythonLibs QUIET)
 if(BUILD_PANGOLIN_GUI AND BUILD_PANGOLIN_VARS AND PYTHONLIBS_FOUND AND NOT _WIN_)
   set(HAVE_PYTHON 1)

--- a/src/utils/posix/condition_variable.cpp
+++ b/src/utils/posix/condition_variable.cpp
@@ -1,0 +1,89 @@
+#include <pangolin/utils/posix/condition_variable.h>
+
+#include <pangolin/utils/posix/shared_memory_buffer.h>
+
+#include <pthread.h>
+
+using namespace std;
+
+namespace pangolin {
+
+struct PThreadSharedData {
+  pthread_mutex_t lock;
+  pthread_cond_t cond;
+};
+
+class PThreadConditionVariable : public ConditionVariableInterface {
+public:
+  PThreadConditionVariable(boostd::shared_ptr<SharedMemoryBufferInterface> &shmem)
+      : _shmem(shmem),
+        _pthread_data(reinterpret_cast<PThreadSharedData *>(_shmem->ptr())) {}
+
+  ~PThreadConditionVariable() {}
+
+  void wait() {
+    _lock();
+    pthread_cond_wait(&_pthread_data->cond, &_pthread_data->lock);
+    _unlock();
+  }
+
+  bool wait(basetime abstime) {
+    struct timespec pthread_abstime = {.tv_sec = abstime.tv_sec,
+                                       .tv_nsec = abstime.tv_usec * 1000};
+    _lock();
+    int err = pthread_cond_timedwait(&_pthread_data->cond, &_pthread_data->lock,
+                           &pthread_abstime);
+    _unlock();
+
+    return 0 == err;
+  }
+
+  void signal() { pthread_cond_signal(&_pthread_data->cond); }
+
+  void broadcast() { pthread_cond_broadcast(&_pthread_data->cond); }
+
+private:
+  void _lock() { pthread_mutex_lock(&_pthread_data->lock); }
+
+  void _unlock() { pthread_mutex_unlock(&_pthread_data->lock); }
+
+  boostd::shared_ptr<SharedMemoryBufferInterface> _shmem;
+  PThreadSharedData *_pthread_data;
+};
+
+boostd::shared_ptr<ConditionVariableInterface>
+create_named_condition_variable(const string &name) {
+  boostd::shared_ptr<SharedMemoryBufferInterface> shmem =
+      create_named_shared_memory_buffer(name, sizeof(PThreadSharedData));
+  boostd::shared_ptr<ConditionVariableInterface> ptr;
+
+  PThreadSharedData *pthread_data =
+      reinterpret_cast<PThreadSharedData *>(shmem->ptr());
+
+  pthread_mutexattr_t mattr;
+  pthread_mutexattr_init(&mattr);
+  pthread_mutexattr_setpshared(&mattr, PTHREAD_PROCESS_SHARED);
+
+  pthread_condattr_t cattr;
+  pthread_condattr_init(&cattr);
+  pthread_condattr_setpshared(&cattr, PTHREAD_PROCESS_SHARED);
+
+  pthread_mutex_init(&pthread_data->lock, &mattr);
+  pthread_cond_init(&pthread_data->cond, &cattr);
+
+  ptr.reset(static_cast<ConditionVariableInterface *>(
+      new PThreadConditionVariable(shmem)));
+  return ptr;
+}
+
+boostd::shared_ptr<ConditionVariableInterface>
+open_named_condition_variable(const string &name) {
+  boostd::shared_ptr<SharedMemoryBufferInterface> shmem =
+    open_named_shared_memory_buffer(name, true);
+  boostd::shared_ptr<ConditionVariableInterface> ptr;
+
+  ptr.reset(new PThreadConditionVariable(shmem));
+  return ptr;
+}
+
+}

--- a/src/utils/posix/semaphore.cpp
+++ b/src/utils/posix/semaphore.cpp
@@ -1,0 +1,83 @@
+#include <pangolin/utils/posix/semaphore.h>
+
+#include <fcntl.h>
+#include <semaphore.h>
+#include <sys/stat.h>
+
+#include <string>
+
+using namespace std;
+
+namespace pangolin
+{
+
+// TODO(shaheen) register a signal handler for SIGTERM and unlink shared
+// semaphores.
+class PosixSemaphore : public SemaphoreInterface
+{
+public:
+  PosixSemaphore(sem_t *semaphore, bool ownership, const string& name) :
+    _semaphore(semaphore),
+    _ownership(ownership),
+    _name(name)
+  {
+  }
+
+  ~PosixSemaphore()
+  {
+    if (_ownership) {
+      sem_unlink(_name.c_str());
+    } else {
+      sem_close(_semaphore);
+    }
+  }
+
+  bool tryAcquire()
+  {
+    int err = sem_trywait(_semaphore);
+    return err == 0;
+  }
+
+  void acquire()
+  {
+    sem_wait(_semaphore);
+  }
+
+  void release()
+  {
+    sem_post(_semaphore);
+  }
+
+private:
+  sem_t *_semaphore;
+  bool _ownership;
+  string _name;
+};
+
+boostd::shared_ptr<SemaphoreInterface> create_named_semaphore(const string& name, unsigned int value)
+{
+  boostd::shared_ptr<SemaphoreInterface> ptr;
+  sem_t *semaphore = sem_open(name.c_str(), O_CREAT | O_EXCL,
+    S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP, value);
+  if (NULL == semaphore) {
+    return ptr;
+  }
+
+  ptr.reset(new PosixSemaphore(semaphore, true, name));
+  return ptr;
+}
+
+boostd::shared_ptr<SemaphoreInterface> open_named_semaphore(const string& name)
+{
+  boostd::shared_ptr<SemaphoreInterface> ptr;
+  sem_t *semaphore = sem_open(name.c_str(), 0);
+
+  if (NULL == semaphore) {
+    return ptr;
+  }
+
+  ptr.reset(new PosixSemaphore(semaphore, false, name));
+  return ptr;
+}
+
+}

--- a/src/utils/posix/shared_memory_buffer.cpp
+++ b/src/utils/posix/shared_memory_buffer.cpp
@@ -1,0 +1,134 @@
+#include <pangolin/utils/posix/shared_memory_buffer.h>
+
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+using namespace std;
+
+namespace pangolin
+{
+
+// TODO(shaheen) register a signal handler for SIGTERM and unlink shared memory
+// objects.
+class PosixSharedMemoryBuffer : public SharedMemoryBufferInterface
+{
+public:
+  PosixSharedMemoryBuffer(int fd, unsigned char *ptr, size_t size, bool ownership, const std::string& name) :
+    _fd(fd),
+    _ptr(ptr),
+    _size(size),
+    _ownership(ownership),
+    _name(name),
+    _lockCount(0)
+  {
+  }
+
+  ~PosixSharedMemoryBuffer()
+  {
+    close(_fd);
+    munmap(_ptr, _size);
+
+    if (_ownership) {
+      shm_unlink(_name.c_str());
+    }
+  }
+
+  bool tryLock()
+  {
+    if (_lockCount == 0) {
+      int err = flock(_fd, LOCK_EX|LOCK_NB);
+      if (0 == err) {
+        _lockCount++;
+      }
+    }
+    return _lockCount != 0;
+  }
+
+  void lock()
+  {
+    if (_lockCount == 0) {
+      flock(_fd, LOCK_EX);
+    }
+    _lockCount++;
+  }
+
+  void unlock()
+  {
+    if (_lockCount != 0) {
+      flock(_fd, LOCK_UN);
+    }
+    _lockCount--;
+  }
+
+  unsigned char *ptr()
+  {
+    return _ptr;
+  }
+
+  std::string name()
+  {
+    return _name;
+  }
+
+private:
+  int _fd;
+  unsigned char *_ptr;
+  size_t _size;
+  bool _ownership;
+  string _name;
+  unsigned int _lockCount;
+};
+
+boostd::shared_ptr<SharedMemoryBufferInterface> create_named_shared_memory_buffer(const
+  string& name, size_t size)
+{
+  boostd::shared_ptr<SharedMemoryBufferInterface> ptr;
+
+  int fd = shm_open(name.c_str(), O_RDWR | O_RDONLY | O_CREAT,
+    S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+  if (-1 == fd) {
+    return ptr;
+  }
+
+  int err = ftruncate(fd, size);
+  if (-1 == err) {
+    shm_unlink(name.c_str());
+    return ptr;
+  }
+
+  unsigned char *buffer = reinterpret_cast<unsigned char *>(mmap(NULL, size,
+      PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0));
+
+  ptr.reset(new PosixSharedMemoryBuffer(fd, buffer, size, true, name));
+  return ptr;
+}
+
+boostd::shared_ptr<SharedMemoryBufferInterface> open_named_shared_memory_buffer(const
+  string& name, bool readwrite)
+{
+  boostd::shared_ptr<SharedMemoryBufferInterface> ptr;
+
+  int fd = shm_open(name.c_str(), readwrite ? O_RDWR | O_RDONLY : O_RDONLY, 0);
+  if (-1 == fd) {
+    return ptr;
+  }
+
+  struct stat sbuf;
+  int err = fstat(fd, &sbuf);
+  if (-1 == err) {
+    return ptr;
+  }
+
+  size_t size = sbuf.st_size;
+  unsigned char *buffer = reinterpret_cast<unsigned char *>(mmap(NULL, size,
+      PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0));
+
+  ptr.reset(new PosixSharedMemoryBuffer(fd, buffer, size, false, name));
+  return ptr;
+}
+
+}

--- a/src/video/drivers/shared_memory.cpp
+++ b/src/video/drivers/shared_memory.cpp
@@ -1,0 +1,64 @@
+#include <pangolin/video/drivers/shared_memory.h>
+
+using namespace std;
+
+namespace pangolin
+{
+
+SharedMemoryVideo::SharedMemoryVideo(size_t w, size_t h, std::string pix_fmt,
+    const boostd::shared_ptr<SharedMemoryBufferInterface>& shared_memory,
+    const boostd::shared_ptr<ConditionVariableInterface>& buffer_full) :
+    _fmt(VideoFormatFromString(pix_fmt)),
+    _w(w),
+    _h(h),
+    _frame_size(w*h*_fmt.bpp/8),
+    _shared_memory(shared_memory),
+    _buffer_full(buffer_full)
+{
+    const StreamInfo stream(_fmt, w, h, _frame_size, 0);
+    _streams.push_back(stream);
+}
+
+SharedMemoryVideo::~SharedMemoryVideo()
+{
+}
+
+void SharedMemoryVideo::Start()
+{
+}
+
+void SharedMemoryVideo::Stop()
+{
+}
+
+size_t SharedMemoryVideo::SizeBytes() const
+{
+    return _frame_size;
+}
+
+const std::vector<StreamInfo>& SharedMemoryVideo::Streams() const
+{
+    return _streams;
+}
+
+bool SharedMemoryVideo::GrabNext(unsigned char* image, bool wait)
+{
+    if (wait) {
+        _buffer_full->wait();
+    } else if (!_buffer_full->wait(TimeNow())) {
+        return false;
+    }
+
+    _shared_memory->lock();
+    memcpy(image, _shared_memory->ptr(), _frame_size);
+    _shared_memory->unlock();
+
+    return true;
+}
+
+bool SharedMemoryVideo::GrabNewest(unsigned char* image, bool wait)
+{
+    return GrabNext(image,wait);
+}
+
+}


### PR DESCRIPTION
This PR creates a virtual camera driver that can be driven via POSIX shared memory. A producer creates a shared memory buffer and a condition variable to signal that it is full. A consumer can create the `SharedMemoryVideo` driver and poll via `VideoInterface`