### PR TITLE
Do not set GLX_SAMPLES when asking for framebuffer options

### DIFF
--- a/src/display/device/display_x11.cpp
+++ b/src/display/device/display_x11.cpp
@@ -120,8 +120,8 @@ int CreateX11Window(
         GLX_DEPTH_SIZE      , 24,
         GLX_STENCIL_SIZE    , 8,
         GLX_DOUBLEBUFFER    , glx_doublebuffer ? True : False,
-        GLX_SAMPLE_BUFFERS  , glx_sample_buffers,
-        GLX_SAMPLES         , glx_sample_buffers > 0 ? glx_samples : 0,
+        // GLX_SAMPLE_BUFFERS  , glx_sample_buffers,
+        // GLX_SAMPLES         , glx_sample_buffers > 0 ? glx_samples : 0,
         None
     };
 


### PR DESCRIPTION
Using on virtual machines people are getting the following error:

```
terminate called after throwing an instance of 'std::runtime_error'
what(): Pangolin X11: Unable to retrieve framebuffer options
```

see (https://github.com/stevenlovegrove/Pangolin/issues/74, https://github.com/stevenlovegrove/Pangolin/issues/80, https://github.com/raulmur/ORB_SLAM2/issues/4 and https://github.com/raulmur/ORB_SLAM2/issues/15)

This PR solves the problem by not setting the GLX_SAMPLES option when asking for framebuffer options as done in this tutorial as it is done in this [tutorial](https://www.opengl.org/wiki/Tutorial:_OpenGL_3.0_Context_Creation_(GLX)).  As far as i understand, the GLX_SAMPLE_BUFFERS and GLX_SAMPLES are set later on the same function anyway