### PR TITLE
Fix memory corruption in DataLog destructor

### DIFF
--- a/include/pangolin/plot/datalog.h
+++ b/include/pangolin/plot/datalog.h
@@ -94,6 +94,7 @@ public:
         samples = 0;
         if(nextBlock) {
             delete nextBlock;
+            nextBlock = NULL;
         }
     }
 


### PR DESCRIPTION
This pointer would be freed multiple times, resulting in memory corruption.