### PR TITLE
Pleora generic parameters

### DIFF
--- a/include/pangolin/utils/params.h
+++ b/include/pangolin/utils/params.h
@@ -32,7 +32,7 @@
 #include <pangolin/utils/type_convert.h>
 
 #include <string>
-#include <map>
+#include <vector>
 
 namespace pangolin
 {
@@ -40,28 +40,35 @@ namespace pangolin
 class PANGOLIN_EXPORT Params
 {
 public:
-    typedef std::map<std::string,std::string> ParamMap;
+    typedef std::vector<std::pair<std::string,std::string>> ParamMap;
 
     bool Contains(const std::string& key) const
     {
-        return params.find(key) != params.end();
+        for(ParamMap::const_iterator it = params.begin(); it!=params.end(); ++it) {
+            if(it->first == key) return true;
+        }
+        return false;
     }
 
     template<typename T>
     T Get(const std::string& key, T default_val) const
     {
-        ParamMap::const_iterator v = params.find(key);
-        if(v != params.end()) {
-            return Convert<T, std::string>::Do(v->second);
-        }else{
-            return default_val;
+        for(ParamMap::const_iterator it = params.begin(); it!=params.end(); ++it) {
+            if(it->first == key) return Convert<T, std::string>::Do(it->second);
         }
+        return default_val;
     }
 
     template<typename T>
     void Set(const std::string& key, const T& val)
     {
-        params[key] = Convert<std::string,T>::Do(val);
+        for(ParamMap::iterator it = params.begin(); it!=params.end(); ++it) {
+            if(it->first == key) {
+                it->second = Convert<std::string,T>::Do(val);
+                return;
+            }
+        }
+        params.push_back(std::pair<std::string,std::string>(key,Convert<std::string,T>::Do(val)));
     }
 
     ParamMap params;

--- a/include/pangolin/video/drivers/pleora.h
+++ b/include/pangolin/video/drivers/pleora.h
@@ -77,6 +77,9 @@ public:
     PleoraVideo(const char *model_name, const char *serial_num, size_t index, size_t bpp = 8, size_t binX = 1, size_t binY = 1, size_t buffer_count = DEFAULT_BUFFER_COUNT,
                 size_t desired_size_x = 0, size_t desired_size_y = 0, size_t desired_pos_x = 0, size_t desired_pos_y = 0, int again = -1, double exposure = 0,
                 bool ext_trig=false, size_t analog_black_level=0, bool use_separate_thread = false, bool get_temperature=false);
+
+    PleoraVideo(Params& p);
+
     ~PleoraVideo();
 
     void Start();
@@ -118,8 +121,11 @@ public:
     bool DropNFrames(uint32_t n);
 
     void operator()();
+
 protected:
+
     void InitDevice(const char *model_name, const char *serial_num, size_t index);
+
     void DeinitDevice();
 
     void SetDeviceParams(
@@ -128,7 +134,10 @@ protected:
         int analog_gain, double exposure, bool ext_trig, size_t analog_black_level
     );
 
+    void SetDeviceParams(Params& p);
+
     void InitStream();
+
     void DeinitStream();
 
     void InitPangoStreams();

--- a/include/pangolin/video/drivers/pleora.h
+++ b/include/pangolin/video/drivers/pleora.h
@@ -74,10 +74,6 @@ public:
 
     static const size_t DEFAULT_BUFFER_COUNT = 30;
 
-    PleoraVideo(const char *model_name, const char *serial_num, size_t index, size_t bpp = 8, size_t binX = 1, size_t binY = 1, size_t buffer_count = DEFAULT_BUFFER_COUNT,
-                size_t desired_size_x = 0, size_t desired_size_y = 0, size_t desired_pos_x = 0, size_t desired_pos_y = 0, int again = -1, double exposure = 0,
-                bool ext_trig=false, size_t analog_black_level=0, bool use_separate_thread = false, bool get_temperature=false);
-
     PleoraVideo(Params& p);
 
     ~PleoraVideo();
@@ -127,12 +123,6 @@ protected:
     void InitDevice(const char *model_name, const char *serial_num, size_t index);
 
     void DeinitDevice();
-
-    void SetDeviceParams(
-        size_t bpp,  size_t binX, size_t binY,
-        size_t desired_size_x, size_t desired_size_y, size_t desired_pos_x, size_t desired_pos_y,
-        int analog_gain, double exposure, bool ext_trig, size_t analog_black_level
-    );
 
     void SetDeviceParams(Params& p);
 

--- a/include/pangolin/video/video.h
+++ b/include/pangolin/video/video.h
@@ -81,8 +81,9 @@
 //  e.g. "depthsense://"
 //  e.g. "depthsense:[img1=depth,img2=rgb]//"
 //
-// pleora - USB 3 vision cameras
-//  e.g. "pleora:[use_seprate_thread=true,bpp=10,size=512x256,pos=712x512,again=1,sn=00000274,exposure=3000,eTrig=true,buffers=10]//"
+// pleora - USB 3 vision cameras accepts any option in the same format reported by eBUSPlayer
+//  e.g. for lightwise cameras: "pleora:[use_seprate_thread=true,size=512x256,pos=712x512,sn=00000274,ExposureTime=10000,PixelFormat=Mono12p,AcquisitionMode=SingleFrame,TriggerSource=Line0,TriggerMode=On]//"
+//  e.g. for toshiba cameras: "pleora:[use_seprate_thread=true,size=512x256,pos=712x512,sn=0300056,PixelSize=Bpp12,ExposureTime=10000,ImageFormatSelector=Format1,BinningHorizontal=2,BinningVertical=2]//"
 //
 // convert - use FFMPEG to convert between video pixel formats
 //  e.g. "convert:[fmt=RGB24]//v4l:///dev/video0"

--- a/src/utils/uri.cpp
+++ b/src/utils/uri.cpp
@@ -67,7 +67,7 @@ Uri ParseUri(const std::string &str_uri)
                 Split(params[i], '=', args );
                 std::string key = Trim(args[0]);
                 std::string val = args.size() > 1 ? Trim(args[1]) : "";
-                uri.params[key] = val;
+                uri.Set(key,val);
             }
         }else{
             throw std::runtime_error("Unable to parse URI: '" + str_uri + "'");

--- a/src/video/drivers/pleora.cpp
+++ b/src/video/drivers/pleora.cpp
@@ -192,11 +192,6 @@ PleoraVideo::PleoraVideo(Params& p): size_bytes(0), lPvSystem(0), lDevice(0), lS
         }
     }
 
-    // Safe-start sequence to prevent TIMEOUT on some cameras with external triggering.
-    InitDevice(mn.empty() ? 0 : mn.c_str(), sn.empty() ? 0 : sn.c_str(), index);
-    SetDeviceParams(device_params);
-    DeinitDevice();
-
     InitDevice(mn.empty() ? 0 : mn.c_str(), sn.empty() ? 0 : sn.c_str(), index);
     SetDeviceParams(device_params);
     InitStream();
@@ -286,8 +281,6 @@ void PleoraVideo::SetDeviceParams(Params& p) {
             getTemp = p.Get<bool>("get_temperature",false);
         } else {
             try {
-                lDeviceParams->InvalidateCache();
-                lDeviceParams->Poll();
                 PvGenParameter* par = lDeviceParams->Get(PvString(it->first.c_str()));
                 if(par) {
                   PvResult r = par->FromString(PvString(it->second.c_str()));

--- a/src/video/drivers/pleora.cpp
+++ b/src/video/drivers/pleora.cpp
@@ -137,6 +137,8 @@ VideoPixelFormat PleoraFormat(const PvGenEnum* pfmt)
         return VideoFormatFromString("GRAY10");
     } else if( !spfmt.compare("Mono12p") ) {
         return VideoFormatFromString("GRAY12");
+    } else if( !spfmt.compare("Mono10") || !spfmt.compare("Mono12")) {
+        return VideoFormatFromString("GRAY16LE");
     } else {
         throw VideoException("Unknown Pleora pixel format", spfmt);
     }

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -723,9 +723,8 @@ VideoInterface* OpenVideo(const Uri& uri)
     }else
 #endif
 #ifdef HAVE_PLEORA
-     if (!uri.scheme.compare("newpleora")) {
+     if (!uri.scheme.compare("pleora")) {
          Params params;
-         // Process back to front to respect the order the params have in the command line.
          for(Params::ParamMap::const_iterator it = uri.params.begin(); it != uri.params.end(); it++) {
              if(it->first == "size"){
                  const ImageDim size = uri.Get<ImageDim>("size", ImageDim(0,0));
@@ -747,34 +746,6 @@ VideoInterface* OpenVideo(const Uri& uri)
          }
          video = new PleoraVideo(params);
     } else
-    if (!uri.scheme.compare("pleora")) {
-        const std::string model_name = uri.Get<std::string>("model", "");
-        const std::string serial_num = uri.Get<std::string>("sn", "");
-        const size_t idx = uri.Get<size_t>("idx",0);
-        const size_t buffer_count = uri.Get<size_t>("buffers", PleoraVideo::DEFAULT_BUFFER_COUNT);
-        const ImageDim desired_size = uri.Get<ImageDim>("size", ImageDim(0,0));
-        const ImageDim desired_pos  = uri.Get<ImageDim>("pos", ImageDim(0,0));
-
-        const size_t binx = uri.Get<size_t>("binx",1);
-        const size_t biny = uri.Get<size_t>("biny",1);
-        const size_t bpp = uri.Get<size_t>("bpp",8);
-
-        const size_t again = uri.Get<size_t>("again",-1);
-        const double exposure = uri.Get<size_t>("exposure",0);
-        const bool ext_trig = uri.Get<bool>("eTrig",false);
-        const size_t analog_black_level= uri.Get<size_t>("abl",0);
-        const bool use_separate_thread = uri.Get<bool>("use_separate_thread",false);
-        const bool get_temperature = uri.Get<bool>("get_temperature",false);
-
-        video = new PleoraVideo(
-            model_name.empty() ? 0 : model_name.c_str(),
-            serial_num.empty() ? 0 : serial_num.c_str(),
-            idx, bpp, binx, biny, buffer_count,
-            desired_size.x, desired_size.y, desired_pos.x, desired_pos.y,
-            again, exposure, ext_trig, analog_black_level, use_separate_thread,
-            get_temperature
-        );
-    }else
 #endif
 #ifdef _UNIX_
     if (!uri.scheme.compare("shmem")) {

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -78,6 +78,7 @@
 #include <pangolin/video/drivers/join.h>
 
 #include <map>
+#include <stdlib.h>
 
 #ifdef _UNIX_
 #include <pangolin/utils/posix/shared_memory_buffer.h>
@@ -722,16 +723,42 @@ VideoInterface* OpenVideo(const Uri& uri)
     }else
 #endif
 #ifdef HAVE_PLEORA
+     if (!uri.scheme.compare("newpleora")) {
+         Params params;
+         // Process back to front to respect the order the params have in the command line.
+         for(Params::ParamMap::const_iterator it = uri.params.begin(); it != uri.params.end(); it++) {
+             if(it->first == "size"){
+                 const ImageDim size = uri.Get<ImageDim>("size", ImageDim(0,0));
+                 std::stringstream sx,sy;
+                 sx << size.x;
+                 sy << size.y;
+                 params.Set("Width", sx.str());
+                 params.Set("Height", sy.str());
+             } else if(it->first == "pos"){
+                 const ImageDim pos  = uri.Get<ImageDim>("pos", ImageDim(0,0));
+                 std::stringstream sx,sy;
+                 sx << pos.x;
+                 sy << pos.y;
+                 params.Set("OffsetX", sx.str());
+                 params.Set("OffsetY", sy.str());
+             } else {
+                 params.Set(it->first, it->second);
+             }
+         }
+         video = new PleoraVideo(params);
+    } else
     if (!uri.scheme.compare("pleora")) {
         const std::string model_name = uri.Get<std::string>("model", "");
         const std::string serial_num = uri.Get<std::string>("sn", "");
         const size_t idx = uri.Get<size_t>("idx",0);
-        const size_t bpp = uri.Get<size_t>("bpp",8);
-        const size_t binx = uri.Get<size_t>("binx",1);
-        const size_t biny = uri.Get<size_t>("biny",1);
         const size_t buffer_count = uri.Get<size_t>("buffers", PleoraVideo::DEFAULT_BUFFER_COUNT);
         const ImageDim desired_size = uri.Get<ImageDim>("size", ImageDim(0,0));
         const ImageDim desired_pos  = uri.Get<ImageDim>("pos", ImageDim(0,0));
+
+        const size_t binx = uri.Get<size_t>("binx",1);
+        const size_t biny = uri.Get<size_t>("biny",1);
+        const size_t bpp = uri.Get<size_t>("bpp",8);
+
         const size_t again = uri.Get<size_t>("again",-1);
         const double exposure = uri.Get<size_t>("exposure",0);
         const bool ext_trig = uri.Get<bool>("eTrig",false);


### PR DESCRIPTION
Updating pleora driver to use generic options directly from command line.
To maintain ordering it was necessary to turn ParamMap into a std::vector.