### PR TITLE
Command line support for repeated options.

### DIFF
--- a/include/pangolin/utils/params.h
+++ b/include/pangolin/utils/params.h
@@ -53,7 +53,8 @@ public:
     template<typename T>
     T Get(const std::string& key, T default_val) const
     {
-        for(ParamMap::const_iterator it = params.begin(); it!=params.end(); ++it) {
+        // Return last value passed to the key.
+        for(ParamMap::const_reverse_iterator it = params.rbegin(); it!=params.rend(); ++it) {
             if(it->first == key) return Convert<T, std::string>::Do(it->second);
         }
         return default_val;
@@ -62,12 +63,6 @@ public:
     template<typename T>
     void Set(const std::string& key, const T& val)
     {
-        for(ParamMap::iterator it = params.begin(); it!=params.end(); ++it) {
-            if(it->first == key) {
-                it->second = Convert<std::string,T>::Do(val);
-                return;
-            }
-        }
         params.push_back(std::pair<std::string,std::string>(key,Convert<std::string,T>::Do(val)));
     }
 

--- a/include/pangolin/video/video.h
+++ b/include/pangolin/video/video.h
@@ -86,7 +86,7 @@
 //  e.g. for toshiba cameras: "pleora:[size=512x256,pos=712x512,sn=0300056,PixelSize=Bpp12,ExposureTime=10000,ImageFormatSelector=Format1,BinningHorizontal=2,BinningVertical=2]//"
 //  e.g. toshiba alternated "pleora:[UserSetSelector=UserSet1,ExposureTime=10000,PixelSize=Bpp12,Width=1400,OffsetX=0,Height=1800,OffsetY=124,LineSelector=Line1,LineSource=ExposureActive,LineSelector=Line2,LineSource=Off,LineModeAll=6,LineInverterAll=6,UserSetSave=Execute,
 //                                   UserSetSelector=UserSet2,PixelSize=Bpp12,Width=1400,OffsetX=1048,Height=1800,OffsetY=124,ExposureTime=10000,LineSelector=Line1,LineSource=Off,LineSelector=Line2,LineSource=ExposureActive,LineModeAll=6,LineInverterAll=6,UserSetSave=Execute,
-//                                   SequentialShutterIndex=1,SequentialShutterEntry=1,SequentialShutterIndex=2,SequentialShutterEntry=2,SequentialShutterTerminateAt=2,SequentialShutterEnable=On]//"
+//                                   SequentialShutterIndex=1,SequentialShutterEntry=1,SequentialShutterIndex=2,SequentialShutterEntry=2,SequentialShutterTerminateAt=2,SequentialShutterEnable=On,,AcquisitionFrameRateControl=Manual,AcquisitionFrameRate=70]//"
 //
 // thread - thread that continuously pulls from the child streams so that data in, unpackking, debayering can be decoupled from the main application thread
 //  e.g. thread://pleora://

--- a/include/pangolin/video/video.h
+++ b/include/pangolin/video/video.h
@@ -84,6 +84,9 @@
 // pleora - USB 3 vision cameras accepts any option in the same format reported by eBUSPlayer
 //  e.g. for lightwise cameras: "pleora:[size=512x256,pos=712x512,sn=00000274,ExposureTime=10000,PixelFormat=Mono12p,AcquisitionMode=SingleFrame,TriggerSource=Line0,TriggerMode=On]//"
 //  e.g. for toshiba cameras: "pleora:[size=512x256,pos=712x512,sn=0300056,PixelSize=Bpp12,ExposureTime=10000,ImageFormatSelector=Format1,BinningHorizontal=2,BinningVertical=2]//"
+//  e.g. toshiba alternated "pleora:[UserSetSelector=UserSet1,ExposureTime=10000,PixelSize=Bpp12,Width=1400,OffsetX=0,Height=1800,OffsetY=124,LineSelector=Line1,LineSource=ExposureActive,LineSelector=Line2,LineSource=Off,LineModeAll=6,LineInverterAll=6,UserSetSave=Execute,
+//                                   UserSetSelector=UserSet2,PixelSize=Bpp12,Width=1400,OffsetX=1048,Height=1800,OffsetY=124,ExposureTime=10000,LineSelector=Line1,LineSource=Off,LineSelector=Line2,LineSource=ExposureActive,LineModeAll=6,LineInverterAll=6,UserSetSave=Execute,
+//                                   SequentialShutterIndex=1,SequentialShutterEntry=1,SequentialShutterIndex=2,SequentialShutterEntry=2,SequentialShutterTerminateAt=2,SequentialShutterEnable=On]//"
 //
 // thread - thread that continuously pulls from the child streams so that data in, unpackking, debayering can be decoupled from the main application thread
 //  e.g. thread://pleora://

--- a/src/video/drivers/pleora.cpp
+++ b/src/video/drivers/pleora.cpp
@@ -26,7 +26,7 @@
  */
 
 #include <pangolin/video/drivers/pleora.h>
-#include <unistd.h>
+#include <pangolin/compat/thread.h>
 
 #ifdef DEBUGPLEORA
   #include <pangolin/utils/timer.h>
@@ -264,10 +264,10 @@ void PleoraVideo::SetDeviceParams(Params& p) {
                       pango_print_info("Executed Command %s\n", it->first.c_str());
                   }
                   bool done;
-                  int attempts = 100;
+                  int attempts = 20;
                   do {
                       cmd->IsDone(done);
-                      usleep(10000);
+                      boostd::this_thread::sleep_for(boostd::chrono::milliseconds(1000));
                       attempts--;
                   } while(!done && (attempts > 0));
                   if(attempts == 0) {


### PR DESCRIPTION
Pleora added support for generic command line commands through syntax Command=Execute
Params.h allows repeated commands but Get will always return the last value for the key (command line options are read in left to right order).