### PR TITLE
Make pipe video input/output much more robust

### DIFF
--- a/include/pangolin/log/packetstream.h
+++ b/include/pangolin/log/packetstream.h
@@ -207,11 +207,15 @@ protected:
     {
         size_t n = 0;
         size_t v = reader.get();
-        while( v & 0x80 ) {
+        while(reader.good() && (v & 0x80)) {
             n |= v & 0x7F;
             n <<= 7;
             v = reader.get();
         }
+        if (!reader.good()) {
+            return static_cast<size_t>(-1);
+        }
+
         return n|v;
     }
 

--- a/include/pangolin/log/packetstream.h
+++ b/include/pangolin/log/packetstream.h
@@ -192,6 +192,11 @@ public:
         return reader.read(s,n);
     }
 
+    const std::ifstream& stream() const
+    {
+        return reader;
+    }
+
 private:
     void InitInternal();
 

--- a/include/pangolin/log/packetstream.h
+++ b/include/pangolin/log/packetstream.h
@@ -192,6 +192,9 @@ public:
         return reader.read(s,n);
     }
 
+private:
+    void InitInternal();
+
 protected:
     inline int64_t ReadTimestamp()
     {

--- a/include/pangolin/utils/file_utils.h
+++ b/include/pangolin/utils/file_utils.h
@@ -74,9 +74,6 @@ PANGOLIN_EXPORT
 bool IsPipe(const std::string& file);
 
 PANGOLIN_EXPORT
-bool PipeOpen(const std::string& file);
-
-PANGOLIN_EXPORT
 bool IsPipe(int fd);
 
 PANGOLIN_EXPORT

--- a/include/pangolin/utils/file_utils.h
+++ b/include/pangolin/utils/file_utils.h
@@ -77,7 +77,7 @@ PANGOLIN_EXPORT
 bool IsPipe(int fd);
 
 PANGOLIN_EXPORT
-bool PipeOpenForRead(const std::string& file);
+int WritablePipeFileDescriptor(const std::string& file);
 
 PANGOLIN_EXPORT
 int ReadablePipeFileDescriptor(const std::string& file);

--- a/include/pangolin/utils/file_utils.h
+++ b/include/pangolin/utils/file_utils.h
@@ -77,6 +77,15 @@ PANGOLIN_EXPORT
 bool PipeOpen(const std::string& file);
 
 PANGOLIN_EXPORT
+bool IsPipe(int fd);
+
+PANGOLIN_EXPORT
+bool PipeOpenForRead(const std::string& file);
+
+PANGOLIN_EXPORT
+int ReadablePipeFileDescriptor(const std::string& file);
+
+PANGOLIN_EXPORT
 void FlushPipe(const std::string& file);
 
 // TODO: Tidy these inlines up / move them

--- a/include/pangolin/utils/file_utils.h
+++ b/include/pangolin/utils/file_utils.h
@@ -79,8 +79,19 @@ bool IsPipe(int fd);
 PANGOLIN_EXPORT
 int WritablePipeFileDescriptor(const std::string& file);
 
+/**
+ * Open the file for reading. Note that it is opened with O_NONBLOCK.  The pipe
+ * open is done in two stages so that the producer knows a reader is waiting
+ * (but not blocked). The reader then checks PipeHasDataToRead() until it
+ * returns true. The file can then be opened. Note that the file descriptor
+ * should be closed after the read stream has been created so that the write
+ * side of the pipe does not get signaled.
+ */
 PANGOLIN_EXPORT
 int ReadablePipeFileDescriptor(const std::string& file);
+
+PANGOLIN_EXPORT
+bool PipeHasDataToRead(int fd);
 
 PANGOLIN_EXPORT
 void FlushPipe(const std::string& file);

--- a/include/pangolin/video/drivers/pango_video.h
+++ b/include/pangolin/video/drivers/pango_video.h
@@ -80,7 +80,9 @@ protected:
     json::value frame_properties;
     int src_id;
     const std::string filename;
+    bool realtime;
     bool is_pipe;
+    bool is_pipe_open;
 };
 
 }

--- a/include/pangolin/video/drivers/pango_video.h
+++ b/include/pangolin/video/drivers/pango_video.h
@@ -86,6 +86,7 @@ protected:
     bool realtime;
     bool is_pipe;
     bool is_pipe_open;
+    int pipe_fd;
 };
 
 }

--- a/include/pangolin/video/drivers/pango_video.h
+++ b/include/pangolin/video/drivers/pango_video.h
@@ -70,6 +70,9 @@ public:
 
     int Seek(int frameid) PANGOLIN_OVERRIDE;
 
+private:
+    void HandlePipeClosed();
+
 protected:
     int FindSource();
 

--- a/src/log/packetstream.cpp
+++ b/src/log/packetstream.cpp
@@ -324,17 +324,22 @@ void PacketStreamReader::Open(const std::string& filename, bool realtime)
     }
 
     this->realtime = realtime;
-    ++playback_devices;
-
-    const size_t PANGO_MAGIC_LEN = PANGO_MAGIC.size();
-    char buffer[10];
+    is_pipe = pangolin::IsPipe(filename);
 
     reader.open(filename.c_str(), std::ios::in | std::ios::binary);
     if (!reader.good()) {
         throw std::runtime_error("Unable to open file '" + filename + "'.");
     }
 
-    is_pipe = pangolin::IsPipe(filename);
+    InitInternal();
+}
+
+void PacketStreamReader::InitInternal()
+{
+    ++playback_devices;
+
+    const size_t PANGO_MAGIC_LEN = PANGO_MAGIC.size();
+    char buffer[10];
 
     // Check file magic matches expected value
     reader.read(buffer, PANGO_MAGIC_LEN);

--- a/src/utils/file_utils.cpp
+++ b/src/utils/file_utils.cpp
@@ -308,17 +308,16 @@ bool IsPipe(int fd)
 #endif
 }
 
-bool PipeOpenForRead(const std::string& file)
+int WritablePipeFileDescriptor(const std::string& file)
 {
 #ifdef _WIN_
     return false;
 #else
-    int fd = open(file.c_str(), O_WRONLY | O_NONBLOCK);
-    if(fd == -1)
-    {
-        return errno != ENXIO;
-    }
-    return true;
+    // open(2) will return ENXIO when there is no reader on the other
+    // side of the pipe, but only if O_WRONLY|O_NONBLOCK is specified.
+    // The file descriptor can be adjusted to be a blocking file
+    // descriptor if it is valid.
+    return open(file.c_str(), O_WRONLY | O_NONBLOCK);
 #endif // _WIN_
 }
 

--- a/src/utils/file_utils.cpp
+++ b/src/utils/file_utils.cpp
@@ -308,11 +308,6 @@ bool IsPipe(int fd)
 #endif
 }
 
-bool PipeOpen(const std::string& file)
-{
-    return PipeOpenForRead(file);
-}
-
 bool PipeOpenForRead(const std::string& file)
 {
 #ifdef _WIN_

--- a/src/utils/file_utils.cpp
+++ b/src/utils/file_utils.cpp
@@ -373,7 +373,7 @@ void FlushPipe(const std::string& file)
     do
     {
         n = read(fd, buf, sizeof(buf));
-    } while(n != -1);
+    } while(n > 0);
     close(fd);
 #endif
 }

--- a/src/video/drivers/pango_video.cpp
+++ b/src/video/drivers/pango_video.cpp
@@ -29,6 +29,8 @@
 #include <pangolin/utils/file_utils.h>
 #include <pangolin/compat/bind.h>
 
+#include <unistd.h>
+
 namespace pangolin
 {
 
@@ -37,7 +39,8 @@ const std::string pango_video_type = "raw_video";
 PangoVideo::PangoVideo(const std::string& filename, bool realtime)
     : reader(filename, realtime), filename(filename), realtime(realtime),
       is_pipe(pangolin::IsPipe(filename)),
-      is_pipe_open(true)
+      is_pipe_open(true),
+      pipe_fd(-1)
 {
     // N.B. is_pipe_open can default to true since the reader opens the file and
     // reads header information from it, which means the pipe must be open and
@@ -51,6 +54,9 @@ PangoVideo::PangoVideo(const std::string& filename, bool realtime)
 
 PangoVideo::~PangoVideo()
 {
+    if (pipe_fd != -1) {
+        close(pipe_fd);
+    }
 }
 
 size_t PangoVideo::SizeBytes() const
@@ -76,9 +82,21 @@ void PangoVideo::Stop()
 bool PangoVideo::GrabNext( unsigned char* image, bool /*wait*/ )
 {
     if (is_pipe && !is_pipe_open) {
-        int fd = ReadablePipeFileDescriptor(filename);
-        if (fd != -1) {
-            reader.Open(fd, realtime);
+        if (pipe_fd == -1) {
+            pipe_fd = ReadablePipeFileDescriptor(filename);
+        }
+
+        if (pipe_fd == -1) {
+            return false;
+        }
+
+        // Test whether the pipe has data to be read. If so, open the
+        // file stream and start reading. After this point, the file
+        // descriptor is owned by the reader.
+        if (PipeHasDataToRead(pipe_fd)) {
+            reader.Open(filename, realtime);
+            close(pipe_fd);
+            is_pipe_open = true;
         } else {
             return false;
         }
@@ -96,7 +114,7 @@ bool PangoVideo::GrabNext( unsigned char* image, bool /*wait*/ )
             }
             return false;
         }
-    } catch (std::ios_base::failure& ex) {
+    } catch (std::exception& ex) {
         if (is_pipe) {
             HandlePipeClosed();
             return false;

--- a/src/video/drivers/pango_video_output.cpp
+++ b/src/video/drivers/pango_video_output.cpp
@@ -130,13 +130,13 @@ int PangoVideoOutput::WriteStreams(unsigned char* data, const json::value& frame
 {
     if(is_pipe)
     {
-        if(!packetstream.IsOpen() && pangolin::PipeOpen(filename))
+        if(!packetstream.IsOpen() && pangolin::PipeOpenForRead(filename))
         {
             packetstream.Open(filename, packetstream_buffer_size_bytes);
 
             first_frame = true;
         }
-        else if(packetstream.IsOpen() && !pangolin::PipeOpen(filename))
+        else if(packetstream.IsOpen() && !pangolin::PipeOpenForRead(filename))
         {
             packetstream.ForceClose();
 


### PR DESCRIPTION
These commits make pipe input and output much more robust to applications disappearing on either end. With these changes, I was able to have sample applications start/stop and have them pick right back up where they left off.

The first couple of commits add some infrastructure to be used later. `PacketStreamReader` is refactored a bit next. Then, reader and writer code paths are both made more robust.

`PipeOpen` leaks file descriptors, but closing the file descriptor within `PipeOpen` would cause a reader to believe the pipe was empty and that the writer had disappeared. Instead, the file descriptor is kept open until higher level code can figure out what to do with it. Because `PangoVideoOutput` now opens the file before closing this extra file descriptor, the reader doesn't get signaled. Also, it was possible to get stuck in a loop in `FlushPipe` because `read` can return `0` bytes read.

On the reader side, several changes were made within `PacketStreamReader` to be more robust. Format errors still result in exceptions, but if data could not be read, it now fails more gracefully. In `PangoVideo`, a graceful failure or exception from a pipe is treated as a closed pipe. `PacketStreamReader` is closed and `GrabNext` becomes a proxy for checking whether the pipe has data in it. The pipe is opened in two stages: first create a file descriptor, then check whether the pipe has data in it and hydrate `PacketStreamReader`. It is done this way so that the writer knows there is a reader waiting for input. If, instead, the file descriptor was opened, tested, and immediately closed, a "smart" writer that checks whether the pipe is opened for reading would likely never start writing to the pipe again.