### PR TITLE
Added the ability to remove variables (Var<..>) again

### DIFF
--- a/examples/SimpleDisplay/main.cpp
+++ b/examples/SimpleDisplay/main.cpp
@@ -33,13 +33,13 @@ void SampleMethod()
 
 
 int main( int argc, char* argv[] )
-{  
+{
   // Load configuration data
   pangolin::ParseVarsFile("app.cfg");
 
   // Create OpenGL window in single line
   pangolin::CreateWindowAndBind("Main",640,480);
-  
+
   // 3D Mouse handler requires depth testing to be enabled
   glEnable(GL_DEPTH_TEST);
 
@@ -93,10 +93,18 @@ int main( int argc, char* argv[] )
   while( !pangolin::ShouldQuit() )
   {
     // Clear entire screen
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);    
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    if( pangolin::Pushed(a_button) )
+    if( pangolin::Pushed(a_button) ){
       std::cout << "You Pushed a button!" << std::endl;
+      static unsigned count = 0;
+      static pangolin::Var<std::string>* toggle;
+      if(++count % 2) toggle = new pangolin::Var<std::string>("ui.Toggle",std::to_string(count/2));
+      else {
+          toggle->destroy();
+          delete toggle;
+      }
+    }
 
     // Overloading of Var<T> operators allows us to treat them like
     // their wrapped types, eg:
@@ -113,7 +121,7 @@ int main( int argc, char* argv[] )
 
     if( pangolin::Pushed(save_cube) )
         d_cam.SaveOnRender("cube");
-    
+
     if( pangolin::Pushed(record_cube) )
         pangolin::DisplayBase().RecordOnRender("ffmpeg:[fps=50,bps=8388608,unique_filename]//screencap.avi");
 

--- a/include/pangolin/display/widgets/widgets.h
+++ b/include/pangolin/display/widgets/widgets.h
@@ -47,6 +47,7 @@ struct PANGOLIN_EXPORT Panel : public View
     void Render();
     void ResizeChildren();
     static void AddVariable(void* data, const std::string& name, VarValueGeneric& var, bool brand_new);
+    static void RemoveVariable(void* data, const std::string& name);
 };
 
 template<typename T>

--- a/include/pangolin/var/var.h
+++ b/include/pangolin/var/var.h
@@ -269,6 +269,11 @@ public:
         return *var;
     }
 
+    void destroy()
+    {
+        VarState::I().Remove(Meta().full_name);
+    }
+
 protected:
     // Initialise from existing variable, obtain data / accessor
     void InitialiseFromGeneric(VarValueGeneric* v)

--- a/include/pangolin/var/varextra.h
+++ b/include/pangolin/var/varextra.h
@@ -45,10 +45,16 @@ PANGOLIN_EXPORT
 void SaveJsonFile(const std::string& filename, const std::string& prefix="");
 
 PANGOLIN_EXPORT
+void RemoveVariable(const std::string& name);
+
+PANGOLIN_EXPORT
 void ProcessHistoricCallbacks(NewVarCallbackFn callback, void* data, const std::string& filter = "");
 
 PANGOLIN_EXPORT
 void RegisterNewVarCallback(NewVarCallbackFn callback, void* data, const std::string& filter = "");
+
+PANGOLIN_EXPORT
+void RegisterRemoveVarCallback(RemoveVarCallbackFn callback, void* data, const std::string& filter = "");
 
 PANGOLIN_EXPORT
 void RegisterGuiVarChangedCallback(GuiVarChangedCallbackFn callback, void* data, const std::string& filter = "");

--- a/src/display/widgets/widgets.cpp
+++ b/src/display/widgets/widgets.cpp
@@ -142,6 +142,7 @@ Panel::Panel(const std::string& auto_register_var_prefix)
     layout = LayoutVertical;
     RegisterNewVarCallback(&Panel::AddVariable,(void*)this,auto_register_var_prefix);
     ProcessHistoricCallbacks(&Panel::AddVariable,(void*)this,auto_register_var_prefix);
+    RegisterRemoveVarCallback(&Panel::RemoveVariable,(void*)this,auto_register_var_prefix);
 }
 
 void Panel::AddVariable(void* data, const std::string& name, VarValueGeneric& var, bool brand_new )
@@ -181,6 +182,25 @@ void Panel::AddVariable(void* data, const std::string& name, VarValueGeneric& va
         }
     }
     
+    display_mutex.unlock();
+}
+
+void Panel::RemoveVariable(void* data, const std::string& name)
+{
+    Panel* thisptr = (Panel*)data;
+
+    display_mutex.lock();
+
+    ViewMap::iterator pnl = context->named_managed_views.find(name);
+
+    if( pnl != context->named_managed_views.end() ) {
+      thisptr->views.erase(std::remove(thisptr->views.begin(), thisptr->views.end(), pnl->second), thisptr->views.end());
+      thisptr->ResizeChildren();
+
+      delete pnl->second;
+      context->named_managed_views.erase(pnl);
+    }
+
     display_mutex.unlock();
 }
 

--- a/src/var/vars.cpp
+++ b/src/var/vars.cpp
@@ -77,6 +77,11 @@ void RegisterNewVarCallback(NewVarCallbackFn callback, void* data, const std::st
     VarState::I().new_var_callbacks.push_back(NewVarCallback(filter,callback,data));
 }
 
+void RegisterRemoveVarCallback(RemoveVarCallbackFn callback, void* data, const std::string& filter)
+{
+    VarState::I().remove_var_callbacks.push_back(RemoveVarCallback(filter,callback,data));
+}
+
 void RegisterGuiVarChangedCallback(GuiVarChangedCallbackFn callback, void* data, const std::string& filter)
 {
     VarState::I().gui_var_changed_callbacks.push_back(GuiVarChangedCallback(filter,callback,data));
@@ -315,6 +320,12 @@ void SaveJsonFile(const std::string& filename, const string &prefix)
     }else{
         pango_print_error("Unable to serialise to %s\n", filename.c_str());
     }
+}
+
+PANGOLIN_EXPORT
+void RemoveVariable(const std::string& name)
+{
+    VarState::I().Remove(name);
 }
 
 }


### PR DESCRIPTION
In many scenes it might be necessary to display temporary information and in this case it would be helpful to add Variables to a panel and to later delete them again.

This feature has been added to Pangolin. The behaviour is illustrated in the SimpleDisplay example: pressing the button now deletes and adds new Variables.

Since I am only superficially familiar with the Pangolin source, please double-check that I didn't introduce a memory leak somewhere.
