### PR TITLE
Load modelview matrix directly

### DIFF
--- a/src/display/opengl_render_state.cpp
+++ b/src/display/opengl_render_state.cpp
@@ -202,8 +202,8 @@ void OpenGlRenderState::ApplyNView(int view) const
 
     // Leave in MODEVIEW mode
     glMatrixMode(GL_MODELVIEW);
-    modelview_premult[view].Load();
-    modelview.Multiply();
+    OpenGlMatrix m = GetModelViewMatrix(view);
+    m.Load();
 
     if(follow) {
         T_cw.Multiply();


### PR DESCRIPTION
Load the OpenGL model view matrix directly rather than multiplying it on the stack