### PR TITLE
Shared contexts

### DIFF
--- a/include/pangolin/display/device/WinWindow.h
+++ b/include/pangolin/display/device/WinWindow.h
@@ -62,6 +62,10 @@ struct WinWindow : public PangolinGl
 
     void ProcessEvents() PANGOLIN_OVERRIDE;
 
+    HGLRC GetGLRenderContext()
+    {
+        return hGLRC;
+    }
 
 private:
     static LRESULT APIENTRY WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
This set of commits makes the following changes:

- Adds a copy constructor for `GlBufferCudaPtr`
- Improves tracking of the current thread's active PangolinGl context
- Adds explicit context sharing which is necessary on Windows because after a context has been used, it is no longer shareable. It's possible to have the creation code path silently fail when sharing is not permitted, but I think this is better.