### PR TITLE
Export RegisterScheme so that clients can use the function

### DIFF
--- a/include/pangolin/video/video.h
+++ b/include/pangolin/video/video.h
@@ -368,6 +368,10 @@ protected:
     std::vector<VideoInterface*> videos;
 };
 
+//! Allows the client to register a URI scheme
+PANGOLIN_EXPORT
+void RegisterScheme(std::string scheme, const VideoInterfaceFactory& factory);
+
 //! Open Video Interface from string specification (as described in this files header)
 PANGOLIN_EXPORT
 VideoInterface* OpenVideo(const std::string& uri);

--- a/include/pangolin/video/video.h
+++ b/include/pangolin/video/video.h
@@ -370,7 +370,7 @@ protected:
 
 //! Allows the client to register a URI scheme
 PANGOLIN_EXPORT
-void RegisterScheme(std::string scheme, const VideoInterfaceFactory& factory);
+void RegisterVideoScheme(std::string scheme, const VideoInterfaceFactory& factory);
 
 //! Open Video Interface from string specification (as described in this files header)
 PANGOLIN_EXPORT

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -717,7 +717,7 @@ VideoInterface* OpenVideo(const Uri& uri)
     return video;
 }
 
-void RegisterScheme(std::string scheme, const VideoInterfaceFactory& factory)
+void RegisterVideoScheme(std::string scheme, const VideoInterfaceFactory& factory)
 {
     ToLower(scheme);
     if (s_RegisteredUriSchemes.count(scheme) != 0) {

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -717,8 +717,7 @@ VideoInterface* OpenVideo(const Uri& uri)
     return video;
 }
 
-void RegisterScheme(std::string scheme,
-    boostd::function<VideoInterface*(const Uri& uri)>& factory)
+void RegisterScheme(std::string scheme, const VideoInterfaceFactory& factory)
 {
     ToLower(scheme);
     if (s_RegisteredUriSchemes.count(scheme) != 0) {

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -313,6 +313,7 @@ VideoInterface* OpenVideo(const Uri& uri)
         if (!uri.scheme.compare(it->first)) {
             return it->second(uri);
         }
+        ++it;
     }
 
     if(!uri.scheme.compare("test") )


### PR DESCRIPTION
This method needs to be exported so that clients can use it.