### PR TITLE
PacketStream reader dynamic size

### DIFF
--- a/include/pangolin/log/packetstream.h
+++ b/include/pangolin/log/packetstream.h
@@ -36,7 +36,6 @@
 #include <pangolin/utils/picojson.h>
 #include <stdint.h>
 
-
 namespace pangolin
 {
 
@@ -182,7 +181,7 @@ public:
 
     size_t Seek(PacketStreamSourceId src_id, size_t framenum);
 
-    bool ReadToSourcePacketAndLock(PacketStreamSourceId src_id);
+    bool ReadToSourcePacketAndLock(PacketStreamSourceId src_id, size_t* num_src_bytes=nullptr);
 
     void ReleaseSourcePacketLock(PacketStreamSourceId src_id);
 
@@ -212,20 +211,20 @@ protected:
     {
         size_t n = 0;
         size_t v = reader.get();
+        uint32_t shift = 0;
         while(reader.good() && (v & 0x80)) {
-            n |= v & 0x7F;
-            n <<= 7;
+            n |= (v & 0x7F) << shift;
+            shift += 7;
             v = reader.get();
         }
         if (!reader.good()) {
             return static_cast<size_t>(-1);
         }
-
-        return n|v;
+        return n | (v & 0x7F) << shift;
     }
 
     void ProcessMessage();
-    void ProcessMessagesUntilSourcePacket(int& nxt_src_id, int64_t &time_us);
+    void ProcessMessagesUntilSourcePacket(int& nxt_src_id, int64_t &time_us, size_t* num_src_bytes=nullptr);
 
     void SkipSync();
     void ReSync();


### PR DESCRIPTION
Fix for supporting dynamically sized packets in the PacketStream. There was a bug in the ReadCompressedUnsignedInt() function. And the size of the dynamic packet needed to be read from the file as well.