### PR TITLE
fixed Image::Alloc bug causing wrong allocation size and leading to c…

### DIFF
--- a/include/pangolin/image/image.h
+++ b/include/pangolin/image/image.h
@@ -60,7 +60,7 @@ struct Image {
         this->w = w;
         this->h = h;
         this->pitch = pitch;
-        this->ptr = (T*)::operator new(w*pitch);
+        this->ptr = (T*)::operator new(h*pitch);
     }
 
     size_t SizeBytes() const


### PR DESCRIPTION
…rashes for images with aspect ratio < 1

Signed-off-by: Tanner Schmidt <tws10@cs.washington.edu>