### PR TITLE
RenderVboCbo: forward the render mode parameter to RenderVbo

### DIFF
--- a/include/pangolin/gl/glvbo.h
+++ b/include/pangolin/gl/glvbo.h
@@ -45,7 +45,7 @@ GlBuffer MakeTriangleStripIboForVbo(int w, int h);
 
 void RenderVbo(GlBuffer& vbo, GLenum mode = GL_POINTS);
 
-void RenderVboCbo(GlBuffer& vbo, GlBuffer& cbo, bool draw_color = true);
+void RenderVboCbo(GlBuffer& vbo, GlBuffer& cbo, bool draw_color = true, GLenum mode = GL_POINTS);
 
 void RenderVboIbo(GlBuffer& vbo, GlBuffer& ibo, bool draw_mesh = true);
 
@@ -108,7 +108,7 @@ inline void RenderVbo(GlBuffer& vbo, GLenum mode)
     vbo.Unbind();
 }
 
-inline void RenderVboCbo(GlBuffer& vbo, GlBuffer& cbo, bool draw_color)
+inline void RenderVboCbo(GlBuffer& vbo, GlBuffer& cbo, bool draw_color, GLenum mode)
 {
     if(draw_color) {
         cbo.Bind();
@@ -116,7 +116,7 @@ inline void RenderVboCbo(GlBuffer& vbo, GlBuffer& cbo, bool draw_color)
         glEnableClientState(GL_COLOR_ARRAY);
     }
     
-    RenderVbo(vbo);
+    RenderVbo(vbo, mode);
     
     if(draw_color) {
         glDisableClientState(GL_COLOR_ARRAY);


### PR DESCRIPTION
By default, `RenderVboCbo` only draws the coloured points of meshes. This is a problem for triangle meshes without VBO indexing, as these cannot be drawn by `RenderVboIboCbo`. The new optional mode parameter allows to draw such meshes by passing mode `GL_TRIANGLES` to `RenderVboCbo`, e.g.: `pangolin::RenderVboCbo(vertexbuffer, colourbuffer, true, GL_TRIANGLES);`.

`RenderVboCbo` keeps its default behaviour of drawing in mode GL_POINTS.