### PR TITLE
Enabled Wextra flag and fixed several warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
 endif()
 
 if(CPP11_NO_BOOST AND NOT MSVC)
-    set( CMAKE_CXX_FLAGS "-std=c++0x -Wall ${CMAKE_CXX_FLAGS}" )
+    set( CMAKE_CXX_FLAGS "-std=c++0x -Wall -Wextra ${CMAKE_CXX_FLAGS}" )
     if(_CLANG_)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     endif()

--- a/examples/SharedMemoryVideoWriter/main.cpp
+++ b/examples/SharedMemoryVideoWriter/main.cpp
@@ -24,7 +24,7 @@ unsigned char generate_value(basetime t, basetime start)
   return static_cast<unsigned char>(d);
 }
 
-int main(int argc, char *argv[])
+int main(/*int argc, char *argv[]*/)
 {
   std::string shmem_name = "/example";
 
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
     create_named_condition_variable(cond_name);
 
   basetime start = TimeNow();
-  basetime d = {0};
+  basetime d = {0, 0};
   d.tv_usec = 33333;
 
   // Sit in a loop and write gray values based on some timing pattern.

--- a/examples/SimpleDisplay/main.cpp
+++ b/examples/SimpleDisplay/main.cpp
@@ -32,7 +32,7 @@ void SampleMethod()
 }
 
 
-int main( int argc, char* argv[] )
+int main(/*int argc, char* argv[]*/)
 {  
   // Load configuration data
   pangolin::ParseVarsFile("app.cfg");

--- a/examples/SimpleDisplayImage/main.cpp
+++ b/examples/SimpleDisplayImage/main.cpp
@@ -8,7 +8,7 @@ void setImageData(unsigned char * imageArray, int size){
   }
 }
 
-int main( int /*argc*/, char* argv[] )
+int main(/*int argc, char* argv[]*/)
 {
   // Create OpenGL window in single line
   pangolin::CreateWindowAndBind("Main",640,480);

--- a/examples/SimpleMultiDisplay/main.cpp
+++ b/examples/SimpleMultiDisplay/main.cpp
@@ -7,7 +7,7 @@ void setImageData(unsigned char * imageArray, int size){
   }
 }
 
-int main( int /*argc*/, char* argv[] )
+int main(/*int argc, char* argv[]*/)
 {
   // Create OpenGL window in single line
   pangolin::CreateWindowAndBind("Main",640,480);

--- a/examples/SimplePlot/main.cpp
+++ b/examples/SimplePlot/main.cpp
@@ -2,7 +2,7 @@
 
 #include <pangolin/pangolin.h>
 
-int main( int /*argc*/, char* argv[] )
+int main(/*int argc, char* argv[]*/)
 {
   // Create OpenGL window in single line
   pangolin::CreateWindowAndBind("Main",640,480);

--- a/include/pangolin/compat/glutbitmap.h
+++ b/include/pangolin/compat/glutbitmap.h
@@ -75,7 +75,7 @@ inline void glRasterPos2fv(const GLfloat *v){
 }
 #endif // HAVE_GLES
 
-inline void glutBitmapString(void *font, const unsigned char *str)
+inline void glutBitmapString(void */*font*/, const unsigned char *str)
 {
 #ifndef HAVE_GLES
     float g_raster_pos[4];
@@ -87,7 +87,7 @@ inline void glutBitmapString(void *font, const unsigned char *str)
     );
 }
 
-inline int glutBitmapLength(void *font, const unsigned char *str)
+inline int glutBitmapLength(void */*font*/, const unsigned char *str)
 {
     return (int)(pangolin::GlFont::I().Text((const char *)str).Width());
 }

--- a/include/pangolin/python/PyPangoIO.h
+++ b/include/pangolin/python/PyPangoIO.h
@@ -116,7 +116,7 @@ struct PyPangoIO {
 
 PyMethodDef PyPangoIO::Py_methods[] = {
     {"write", (PyCFunction)PyPangoIO::Py_write, METH_VARARGS, "Write to console" },
-    {NULL}
+    {NULL , NULL , 0 , NULL}
 };
 
 PyTypeObject PyPangoIO::Py_type = {
@@ -158,6 +158,15 @@ PyTypeObject PyPangoIO::Py_type = {
     (initproc)PyPangoIO::Py_init,             /* tp_init */
     0,                                        /* tp_alloc */
     (newfunc)PyPangoIO::Py_new,               /* tp_new */
+    0,                                        /* tp_free */
+    0,                                        /* tp_is_gc */
+    0,                                        /* tp_bases */
+    0,                                        /* tp_mro */
+    0,                                        /* tp_cache */
+    0,                                        /* tp_subclasses */
+    0,                                        /* tp_weaklist */
+    0,                                        /* tp_del */
+    0                                         /* tp_version_tag */
 };
 
 }

--- a/include/pangolin/python/PyVar.h
+++ b/include/pangolin/python/PyVar.h
@@ -253,6 +253,15 @@ struct PyVar {
     (initproc)PyVar::Py_init,                 /* tp_init */
     0,                                        /* tp_alloc */
     (newfunc)PyVar::Py_new,                   /* tp_new */
+    0,                                        /* tp_free */
+    0,                                        /* tp_is_gc */
+    0,                                        /* tp_bases */
+    0,                                        /* tp_mro */
+    0,                                        /* tp_cache */
+    0,                                        /* tp_subclasses */
+    0,                                        /* tp_weaklist */
+    0,                                        /* tp_del */
+    0                                         /* tp_version_tag */
 };
 
 }

--- a/include/pangolin/python/PyVar.h
+++ b/include/pangolin/python/PyVar.h
@@ -141,13 +141,13 @@ struct PyVar {
         delete self;
     }
 
-    static PyObject * Py_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+    static PyObject * Py_new(PyTypeObject *type, PyObject */*args*/, PyObject */*kwds*/)
     {
         PyVar* self = new PyVar(type);
         return (PyObject *)self;
     }
 
-    static int Py_init(PyVar *self, PyObject *args, PyObject *kwds)
+    static int Py_init(PyVar *self, PyObject *args, PyObject */*kwds*/)
     {
         char* cNamespace = 0;
         if (!PyArg_ParseTuple(args, "s", &cNamespace))

--- a/include/pangolin/utils/fix_size_buffer_queue.h
+++ b/include/pangolin/utils/fix_size_buffer_queue.h
@@ -143,12 +143,12 @@ public:
         emptyBuffers.push_back(bp);
     }
 
-    const size_t AvailableFrames() const {
+    size_t AvailableFrames() const {
         boostd::lock_guard<boostd::mutex> vlock(vMtx);
         return validBuffers.size();
     }
 
-    const size_t EmptyBuffers() const {
+    size_t EmptyBuffers() const {
         boostd::lock_guard<boostd::mutex> elock(eMtx);
         return emptyBuffers.size();
     }

--- a/src/console/ConsoleView.cpp
+++ b/src/console/ConsoleView.cpp
@@ -201,7 +201,7 @@ inline std::string CommonPrefix(const std::vector<std::string>& vec)
     return vec[0].substr(0,cmn);
 }
 
-void ConsoleView::Keyboard(View&, unsigned char key, int x, int y, bool pressed)
+void ConsoleView::Keyboard(View&, unsigned char key, int /*x*/, int /*y*/, bool pressed)
 {
     static int hist_id = -1;
     static std::string prefix;

--- a/src/display/device/display_x11.cpp
+++ b/src/display/device/display_x11.cpp
@@ -161,7 +161,7 @@ bool isExtensionSupported(const char *extList, const char *extension)
 }
 
 static bool ctxErrorOccurred = false;
-static int ctxErrorHandler( ::Display *dpy, ::XErrorEvent *ev )
+static int ctxErrorHandler( ::Display */*dpy*/, ::XErrorEvent */*ev*/ )
 {
     ctxErrorOccurred = true;
     return 0;

--- a/src/display/widgets/widgets.cpp
+++ b/src/display/widgets/widgets.cpp
@@ -144,7 +144,7 @@ Panel::Panel(const std::string& auto_register_var_prefix)
     ProcessHistoricCallbacks(&Panel::AddVariable,(void*)this,auto_register_var_prefix);
 }
 
-void Panel::AddVariable(void* data, const std::string& name, VarValueGeneric& var, bool brand_new )
+void Panel::AddVariable(void* data, const std::string& name, VarValueGeneric& var, bool /*brand_new*/)
 {
     Panel* thisptr = (Panel*)data;
     
@@ -241,7 +241,7 @@ Button::Button(string title, VarValueGeneric& tv)
     gltext = font().Text(title);
 }
 
-void Button::Mouse(View&, MouseButton button, int x, int y, bool pressed, int mouse_state)
+void Button::Mouse(View&, MouseButton button, int /*x*/, int /*y*/, bool pressed, int /*mouse_state*/)
 {
     if(button == MouseButtonLeft )
     {
@@ -279,7 +279,7 @@ FunctionButton::FunctionButton(string title, VarValueGeneric& tv)
     gltext = font().Text(title);
 }
 
-void FunctionButton::Mouse(View&, MouseButton button, int x, int y, bool pressed, int mouse_state)
+void FunctionButton::Mouse(View&, MouseButton button, int /*x*/, int /*y*/, bool pressed, int /*mouse_state*/)
 {
     if (button == MouseButtonLeft)
     {
@@ -318,7 +318,7 @@ Checkbox::Checkbox(std::string title, VarValueGeneric& tv)
     gltext = font().Text(title);
 }
 
-void Checkbox::Mouse(View&, MouseButton button, int x, int y, bool pressed, int mouse_state)
+void Checkbox::Mouse(View&, MouseButton button, int /*x*/, int /*y*/, bool pressed, int /*mouse_state*/)
 {
     if( button == MouseButtonLeft && pressed ) {
         var->Set(!var->Get());
@@ -375,7 +375,7 @@ Slider::Slider(std::string title, VarValueGeneric& tv)
     is_integral_type = IsIntegral(tv.TypeId());
 }
 
-void Slider::Keyboard(View&, unsigned char key, int x, int y, bool pressed)
+void Slider::Keyboard(View&, unsigned char key, int /*x*/, int /*y*/, bool pressed)
 {
     if( pressed && var->Meta().range[0] < var->Meta().range[1] )
     {
@@ -434,7 +434,7 @@ void Slider::Mouse(View& view, MouseButton button, int x, int y, bool pressed, i
     }
 }
 
-void Slider::MouseMotion(View&, int x, int y, int mouse_state)
+void Slider::MouseMotion(View&, int x, int /*y*/, int /*mouse_state*/)
 {
     if( var->Meta().range[0] != var->Meta().range[1] )
     {
@@ -514,7 +514,7 @@ TextInput::TextInput(std::string title, VarValueGeneric& tv)
     gltext = font().Text(title);
 }
 
-void TextInput::Keyboard(View&, unsigned char key, int x, int y, bool pressed)
+void TextInput::Keyboard(View&, unsigned char key, int /*x*/, int /*y*/, bool pressed)
 {
     if(pressed && do_edit)
     {
@@ -576,7 +576,7 @@ void TextInput::Keyboard(View&, unsigned char key, int x, int y, bool pressed)
     }
 }
 
-void TextInput::Mouse(View& view, MouseButton button, int x, int y, bool pressed, int mouse_state)
+void TextInput::Mouse(View& /*view*/, MouseButton button, int x, int /*y*/, bool pressed, int /*mouse_state*/)
 {
     if(button != MouseWheelUp && button != MouseWheelDown )
     {
@@ -618,7 +618,7 @@ void TextInput::Mouse(View& view, MouseButton button, int x, int y, bool pressed
     }
 }
 
-void TextInput::MouseMotion(View&, int x, int y, int mouse_state)
+void TextInput::MouseMotion(View&, int x, int /*y*/, int /*mouse_state*/)
 {
     if(do_edit)
     {

--- a/src/gl/stb_truetype.h
+++ b/src/gl/stb_truetype.h
@@ -2049,7 +2049,7 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill, 
 // directly AA rasterize edges w/o supersampling
 static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e, int n, int /*vsubsample*/, int off_x, int off_y, void *userdata)
 {
-   stbtt__hheap hh = { 0 };
+   stbtt__hheap hh = { 0, 0, 0 };
    stbtt__active_edge *active = NULL;
    int y,j=0, i;
    float scanline_data[129], *scanline, *scanline2;

--- a/src/gl/stb_truetype.h
+++ b/src/gl/stb_truetype.h
@@ -2047,7 +2047,7 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill, 
 }
 
 // directly AA rasterize edges w/o supersampling
-static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e, int n, int vsubsample, int off_x, int off_y, void *userdata)
+static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e, int n, int /*vsubsample*/, int off_x, int off_y, void *userdata)
 {
    stbtt__hheap hh = { 0 };
    stbtt__active_edge *active = NULL;

--- a/src/handler/handler.cpp
+++ b/src/handler/handler.cpp
@@ -120,7 +120,7 @@ Handler3D::Handler3D(OpenGlRenderState& cam_state, AxisDirection enforce_up, flo
     SetZero<3,1>(rot_center);
 }
 
-void Handler3D::Keyboard(View&, unsigned char key, int x, int y, bool pressed)
+void Handler3D::Keyboard(View&, unsigned char /*key*/, int /*x*/, int /*y*/, bool /*pressed*/)
 {
     // TODO: hooks for reset / changing mode (perspective / ortho etc)
 }
@@ -317,7 +317,7 @@ void Handler3D::MouseMotion(View& display, int x, int y, int button_state)
     last_pos[1] = (float)y;
 }
 
-void Handler3D::Special(View& display, InputSpecial inType, float x, float y, float p1, float p2, float p3, float p4, int button_state)
+void Handler3D::Special(View& display, InputSpecial inType, float x, float y, float p1, float p2, float /*p3*/, float /*p4*/, int button_state)
 {
     if( !(inType == InputSpecialScroll || inType == InputSpecialRotate) )
         return;

--- a/src/log/packetstream.cpp
+++ b/src/log/packetstream.cpp
@@ -459,7 +459,7 @@ bool PacketStreamReader::ReadToSourcePacketAndLock(PacketStreamSourceId src_id, 
     return true;
 }
 
-void PacketStreamReader::ReleaseSourcePacketLock(PacketStreamSourceId src_id)
+void PacketStreamReader::ReleaseSourcePacketLock(PacketStreamSourceId /*src_id*/)
 {
     ReadTag();
     ++packets;

--- a/src/plot/datalog.cpp
+++ b/src/plot/datalog.cpp
@@ -208,7 +208,7 @@ void DataLog::Clear()
     stats.clear();
 }
 
-void DataLog::Save(std::string filename)
+void DataLog::Save(std::string /*filename*/)
 {
     // TODO: Implement
     throw std::runtime_error("Method not implemented");

--- a/src/plot/plotter.cpp
+++ b/src/plot/plotter.cpp
@@ -190,7 +190,7 @@ void Plotter::PlotImplicit::CreateInequality(const std::string& ie, Colour c)
     CreatePlot( oss.str() );
 }
 
-void Plotter::PlotImplicit::CreateDistancePlot(const std::string& dist)
+void Plotter::PlotImplicit::CreateDistancePlot(const std::string& /*dist*/)
 {
 
 }
@@ -864,7 +864,7 @@ void Plotter::ResetView()
     py.target.y = py.rview_default.y;
 }
 
-void Plotter::Keyboard(View&, unsigned char key, int x, int y, bool pressed)
+void Plotter::Keyboard(View&, unsigned char key, int /*x*/, int /*y*/, bool pressed)
 {
     const float mvfactor = 1.0f / 10.0f;
 
@@ -1017,12 +1017,12 @@ void Plotter::MouseMotion(View& view, int x, int y, int button_state)
     last_mouse_pos[1] = y;
 }
 
-void Plotter::PassiveMouseMotion(View&, int x, int y, int button_state)
+void Plotter::PassiveMouseMotion(View&, int x, int y, int /*button_state*/)
 {
     ScreenToPlot(x, y, hover[0], hover[1]);
 }
 
-void Plotter::Special(View&, InputSpecial inType, float x, float y, float p1, float p2, float p3, float p4, int button_state)
+void Plotter::Special(View&, InputSpecial inType, float x, float y, float p1, float p2, float /*p3*/, float /*p4*/, int button_state)
 {
     if(inType == InputSpecialScroll) {
         const float d[2] = {p1,-p2};

--- a/src/python/PyModulePangolin.cpp
+++ b/src/python/PyModulePangolin.cpp
@@ -107,7 +107,7 @@ static PyMethodDef PangoMethods[] = {
 #if defined(BUILD_PANGOLIN_GUI) && defined(BUILD_PANGOLIN_VIDEO)
     {"record_window",  pangolin_record_window, METH_VARARGS, "Record window contents to video file."},
 #endif // defined(BUILD_PANGOLIN_GUI) && defined(BUILD_PANGOLIN_VIDEO)
-    {NULL}
+    {NULL , NULL , 0 , NULL}
 };
 
 #if PY_MAJOR_VERSION >= 3

--- a/src/video/drivers/images.cpp
+++ b/src/video/drivers/images.cpp
@@ -158,7 +158,7 @@ const std::vector<StreamInfo>& ImagesVideo::Streams() const
 }
 
 //! Implement VideoInput::GrabNext()
-bool ImagesVideo::GrabNext( unsigned char* image, bool wait )
+bool ImagesVideo::GrabNext( unsigned char* image, bool /*wait*/ )
 {
     if(next_frame_id < loaded.size()) {
         Frame& frame = loaded[next_frame_id];

--- a/src/video/drivers/test.cpp
+++ b/src/video/drivers/test.cpp
@@ -80,7 +80,7 @@ const std::vector<StreamInfo>& TestVideo::Streams() const
 }
 
 //! Implement VideoInput::GrabNext()
-bool TestVideo::GrabNext( unsigned char* image, bool wait )
+bool TestVideo::GrabNext( unsigned char* image, bool /*wait*/ )
 {
     setRandomData(image, size_bytes);
     return true;

--- a/src/video/drivers/v4l.cpp
+++ b/src/video/drivers/v4l.cpp
@@ -103,7 +103,7 @@ size_t V4lVideo::SizeBytes() const
     return image_size;
 }
 
-bool V4lVideo::GrabNext( unsigned char* image, bool wait )
+bool V4lVideo::GrabNext( unsigned char* image, bool /*wait*/ )
 {
     for (;;) {
         fd_set fds;
@@ -368,7 +368,7 @@ void V4lVideo::init_read(unsigned int buffer_size)
     }
 }
 
-void V4lVideo::init_mmap(const char* dev_name)
+void V4lVideo::init_mmap(const char* /*dev_name*/)
 {
     struct v4l2_requestbuffers req;
     
@@ -421,7 +421,7 @@ void V4lVideo::init_mmap(const char* dev_name)
     }
 }
 
-void V4lVideo::init_userp(const char* dev_name, unsigned int buffer_size)
+void V4lVideo::init_userp(const char* /*dev_name*/, unsigned int buffer_size)
 {
     struct v4l2_requestbuffers req;
     unsigned int page_size;


### PR DESCRIPTION
These commits enable the Wextra flag and fix most warnings related to it. Despite a warning related to the Py_INCREF macro in src/python/PyModulePangolin.cpp, Pangolin compiles without any noise. I may missed some warnings since I have not installed all but the most important libraries Pangolin makes use of.