### PR TITLE
Fixed warning suppression in python module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -235,8 +235,8 @@ if(BUILD_PANGOLIN_GUI AND BUILD_PANGOLIN_VARS AND PYTHONLIBS_FOUND AND NOT _WIN_
     python/PyModulePangolin.cpp
   )
   if(_GCC_)
-      set_source_files_properties(python/PyInterpreter.cpp PROPERTIES COMPILE_FLAGS "-fno-strict-aliasing")
-      set_source_files_properties(python/PyInterpreter.cpp python/PyModulePangolin.cpp PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
+    set_source_files_properties(python/PyInterpreter.cpp    PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers")
+    set_source_files_properties(python/PyModulePangolin.cpp PROPERTIES COMPILE_FLAGS "-fno-strict-aliasing -Wno-missing-field-initializers")
   endif()
   list(APPEND INTERNAL_INC ${PYTHON_INCLUDE_DIR})
   list(APPEND LINK_LIBS    ${PYTHON_LIBRARY})


### PR DESCRIPTION
Your latest commit about suppressing the unresolvable python warning does not work for me on Ubuntu 14.04 with GCC 4.8. set_source_files_properties seems to overwrite the flags when invoked twice on the same file. Therefore, only the flags from the last call are used.

In order to fix that, set_source_files_properties should be called for each file once and all flags should be provided for this call. I observed that python/PyInterpreter.cpp does not need the -fno-strict-aliasing flag anymore (no call of Py_INCREF and no warning on my system with Python 2.7), so I removed it.