### PR TITLE
Fixed unused-parameter warnings in video drivers

### DIFF
--- a/src/video/drivers/depthsense.cpp
+++ b/src/video/drivers/depthsense.cpp
@@ -567,7 +567,7 @@ const std::vector<StreamInfo>& DepthSenseVideo::Streams() const
     return streams;
 }
 
-bool DepthSenseVideo::GrabNext( unsigned char* image, bool wait )
+bool DepthSenseVideo::GrabNext( unsigned char* image, bool /*wait*/ )
 {
     if(fill_image) {
         throw std::runtime_error("GrabNext Cannot be called concurrently");

--- a/src/video/drivers/openni.cpp
+++ b/src/video/drivers/openni.cpp
@@ -189,7 +189,7 @@ void OpenNiVideo::Stop()
     context.StopGeneratingAll();
 }
 
-bool OpenNiVideo::GrabNext( unsigned char* image, bool wait )
+bool OpenNiVideo::GrabNext( unsigned char* image, bool /*wait*/ )
 {
     //    XnStatus nRetVal = context.WaitAndUpdateAll();
     XnStatus nRetVal = context.WaitAnyUpdateAll();


### PR DESCRIPTION
This commit includes two more fixes for unused-parameter warnings. I went through all video drivers and everything should be fine now.