### PR TITLE
Fix typo in include directives

### DIFF
--- a/include/pangolin/video/drivers/depthsense.h
+++ b/include/pangolin/video/drivers/depthsense.h
@@ -32,7 +32,7 @@
 #include <pangolin/video/video.h>
 
 #include <thread>
-#include <mutex
+#include <mutex>
 #include <condition_variable>
 
 // DepthSense SDK for SoftKinetic cameras from Creative


### PR DESCRIPTION
Hi,

This PR fixes a typo that was introduced when removing boost dependencies