### PR TITLE
support for BGRA32 VideoPixelFormat

### DIFF
--- a/include/pangolin/gl/glcuda.h
+++ b/include/pangolin/gl/glcuda.h
@@ -79,7 +79,7 @@ struct GlTextureCudaArray : GlTexture
 
 struct CudaScopedMappedPtr
 {
-    CudaScopedMappedPtr(GlBufferCudaPtr& buffer);
+    CudaScopedMappedPtr(const GlBufferCudaPtr& buffer);
     ~CudaScopedMappedPtr();
     void* operator*();
     cudaGraphicsResource* res;
@@ -90,7 +90,7 @@ private:
 
 struct CudaScopedMappedArray
 {
-    CudaScopedMappedArray(GlTextureCudaArray& tex);
+    CudaScopedMappedArray(const GlTextureCudaArray& tex);
     ~CudaScopedMappedArray();
     cudaArray* operator*();
     cudaGraphicsResource* res;
@@ -195,7 +195,7 @@ inline void GlTextureCudaArray::Reinitialise(int width, int height, GLint intern
     }
 }
 
-inline CudaScopedMappedPtr::CudaScopedMappedPtr(GlBufferCudaPtr& buffer)
+inline CudaScopedMappedPtr::CudaScopedMappedPtr(const GlBufferCudaPtr& buffer)
     : res(buffer.cuda_res)
 {
     cudaGraphicsMapResources(1, &res, 0);
@@ -214,7 +214,7 @@ inline void* CudaScopedMappedPtr::operator*()
     return d_ptr;
 }
 
-inline CudaScopedMappedArray::CudaScopedMappedArray(GlTextureCudaArray& tex)
+inline CudaScopedMappedArray::CudaScopedMappedArray(const GlTextureCudaArray& tex)
     : res(tex.cuda_res)
 {
     cudaGraphicsMapResources(1, &res);

--- a/include/pangolin/gl/glpixformat.h
+++ b/include/pangolin/gl/glpixformat.h
@@ -45,7 +45,7 @@ struct GlPixFormat
         switch( fmt.channels) {
         case 1: glformat = GL_LUMINANCE; break;
         case 3: glformat = (fmt.format == "BGR24" || fmt.format == "BGR48")  ? GL_BGR  : GL_RGB;  break;
-        case 4: glformat = (fmt.format == "BGRA24"|| fmt.format == "BGRA48") ? GL_BGRA : GL_RGBA; break;
+        case 4: glformat = (fmt.format == "BGRA24" || fmt.format == "BGRA32" || fmt.format == "BGRA48") ? GL_BGRA : GL_RGBA; break;
         default: throw std::runtime_error("Unable to form OpenGL format from video format: '" + fmt.format + "'.");
         }
 

--- a/src/image/image_common.cpp
+++ b/src/image/image_common.cpp
@@ -46,6 +46,7 @@ const VideoPixelFormat SupportedVideoPixelFormats[] =
     {"BGR48", 3, {16,16,16}, 48, false},
     {"YUYV422", 3, {4,2,2}, 16, false},
     {"RGBA32",  4, {8,8,8,8}, 32, false},
+    {"BGRA32",  4, {8,8,8,8}, 32, false},
     {"GRAY32F", 1, {32}, 32, false},
     {"GRAY64F", 1, {64}, 64, false},
     {"RGB96F",  3, {32,32,32}, 96, false},


### PR DESCRIPTION
Adding support for "BGRA32" in VideoPixelFormat and GlPixFormat, which is the format for the Kinect2 color stream. 

I'm also unsure of the need for "BGRA24" in line 48 of glpixformat.h, it seems that format is unlikely. "BGRA48" seems similarly unlikely although perhaps plausible. Also, neither appear in the supported formats in image_common.cpp, so they should probably either be added to the one or removed from the other.

Signed-off-by: Tanner Schmidt <tws10@cs.washington.edu>