### PR TITLE
Fixed missing cmath include

### DIFF
--- a/include/pangolin/gl/colour.h
+++ b/include/pangolin/gl/colour.h
@@ -28,6 +28,8 @@
 #ifndef PANGOLIN_COLOUR
 #define PANGOLIN_COLOUR
 
+#include <cmath>
+
 #include <stdexcept>
 
 namespace pangolin


### PR DESCRIPTION
```include/pangolin/gl/colour.h``` makes references to ```floor``` and ```sqrt``` but does not include ```cmath`` for these references to work.