### PR TITLE
Suppressed unused-parameter warnings

### DIFF
--- a/include/pangolin/platform.h
+++ b/include/pangolin/platform.h
@@ -53,6 +53,8 @@
 #   define PANGOLIN_EXPORT
 #endif //_MSVC_
 
+#define PANGOLIN_UNUSED(x) (void)(x)
+
 #ifdef _APPLE_IOS_
 // Not supported on this platform.
 #define __thread

--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -350,6 +350,9 @@ void SaveWindowOnRender(std::string prefix)
 
 void SaveFramebuffer(std::string prefix, const Viewport& v)
 {
+    PANGOLIN_UNUSED(prefix);
+    PANGOLIN_UNUSED(v);
+    
 #ifndef HAVE_GLES
 
 #ifdef HAVE_PNG

--- a/src/display/view.cpp
+++ b/src/display/view.cpp
@@ -60,6 +60,8 @@ double AspectAreaWithinTarget(double target, double test)
 
 void SaveViewFromFbo(std::string prefix, View& view, float scale)
 {
+    PANGOLIN_UNUSED(prefix);
+    
 #ifndef HAVE_GLES
     const Viewport orig = view.v;
     view.v.l = 0;

--- a/src/image/image_io.cpp
+++ b/src/image/image_io.cpp
@@ -25,6 +25,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <pangolin/platform.h>
+
 #include <pangolin/image/image_io.h>
 #include <pangolin/video/drivers/pango.h>
 #include <pangolin/video/drivers/pango_video_output.h>
@@ -192,6 +194,8 @@ void PNGAPI PngWarningsCallback(png_structp /*png_ptr*/, png_const_charp /*warni
 
 TypedImage LoadPng(const std::string& filename)
 {
+    PANGOLIN_UNUSED(filename);
+    
 #ifdef HAVE_PNG
     FILE *in = fopen(filename.c_str(), "rb");
     
@@ -273,6 +277,10 @@ TypedImage LoadPng(const std::string& filename)
 
 void SavePng(const Image<unsigned char>& image, const pangolin::VideoPixelFormat& fmt, const std::string& filename, bool top_line_first)
 {
+    PANGOLIN_UNUSED(image);
+    PANGOLIN_UNUSED(filename);
+    PANGOLIN_UNUSED(top_line_first);
+    
     // Check image has supported bit depth
     for(unsigned int i=1; i < fmt.channels; ++i) {
         if( fmt.channel_bits[i] != fmt.channel_bits[0] ) {
@@ -385,6 +393,8 @@ VideoPixelFormat JpgFormat(jpeg_decompress_struct& /*info*/ )
 
 TypedImage LoadJpg(const std::string& filename)
 {
+    PANGOLIN_UNUSED(filename);
+    
 #ifdef HAVE_JPEG
     FILE * infile = fopen(filename.c_str(), "rb");
 
@@ -521,6 +531,11 @@ void SetOpenEXRChannels(Imf::ChannelList& ch, const pangolin::VideoPixelFormat& 
 
 void SaveExr(const Image<unsigned char>& image_in, const pangolin::VideoPixelFormat& fmt, const std::string& filename, bool top_line_first)
 {
+    PANGOLIN_UNUSED(image_in);
+    PANGOLIN_UNUSED(fmt);
+    PANGOLIN_UNUSED(filename);
+    PANGOLIN_UNUSED(top_line_first);
+    
 #ifdef HAVE_OPENEXR
     Image<unsigned char> image;
 


### PR DESCRIPTION
When building with all optional dependencies disabled, some unused parameter warnings occur. This commit fixes that by suppressing them using the defined `PANGOLIN_UNUSED` macro that works for all compilers.