### PR TITLE
Fixed some Appveyor warnings

### DIFF
--- a/include/pangolin/image/image.h
+++ b/include/pangolin/image/image.h
@@ -78,12 +78,12 @@ struct Image {
         return Image<To>(w,h,pitch, (To*)ptr);
     }
 
-    T* RowPtr(int r)
+    T* RowPtr(size_t r)
     {
         return (T*)((char*)ptr + r*pitch);
     }
 
-    const T* RowPtr(int r) const
+    const T* RowPtr(size_t r) const
     {
         return (T*)((char*)ptr + r*pitch);
     }

--- a/src/video/video_output.cpp
+++ b/src/video/video_output.cpp
@@ -95,7 +95,7 @@ VideoOutput::~VideoOutput()
 
 bool VideoOutput::IsOpen() const
 {
-    return recorder.get();
+    return recorder.get() != nullptr;
 }
 
 void VideoOutput::Open(const std::string& str_uri)


### PR DESCRIPTION
When looking into the logs and messages by Appveyor, there are a couple of warnings emitted. While most of them are related to external libraries like libjpg or caused by an overly picky Visual C++, there are two warnings that should be fixed.

The first commit is related to a warning about an implicit cast of a pointer to `bool`. Although it is not really important, fixing it by a direct check against a null pointer also clarifies the intention of `IsOpen` a bit.

The other commit is more critical since the user might pass a negative row number to an image object and would get a pointer to an illegal memory position. Thanks to the warning about an implicit cast of `size_t` to `int`, this is now fixed.