### PR TITLE
Travis warnings

### DIFF
--- a/include/pangolin/console/ConsoleView.h
+++ b/include/pangolin/console/ConsoleView.h
@@ -76,9 +76,9 @@ public:
     // Replace implementation in View to account for hiding animation
     bool IsShown() const;
 
-    void Render() PANGOLIN_OVERRIDE;
+    void Render() override;
 
-    void Keyboard(View&, unsigned char key, int x, int y, bool pressed) PANGOLIN_OVERRIDE;
+    void Keyboard(View&, unsigned char key, int x, int y, bool pressed) override;
 
 private:
     void DrawLine(const ConsoleView::Line& l);

--- a/include/pangolin/display/device/OsxWindow.h
+++ b/include/pangolin/display/device/OsxWindow.h
@@ -46,17 +46,17 @@ struct OsxWindow : public PangolinGl
 
     void StopFullScreen();
 
-    void ToggleFullscreen() PANGOLIN_OVERRIDE;
+    void ToggleFullscreen() override;
 
-    void Move(int x, int y) PANGOLIN_OVERRIDE;
+    void Move(int x, int y) override;
 
-    void Resize(unsigned int w, unsigned int h) PANGOLIN_OVERRIDE;
+    void Resize(unsigned int w, unsigned int h) override;
 
-    void MakeCurrent() PANGOLIN_OVERRIDE;
+    void MakeCurrent() override;
 
-    void SwapBuffers() PANGOLIN_OVERRIDE;
+    void SwapBuffers() override;
 
-    void ProcessEvents() PANGOLIN_OVERRIDE;
+    void ProcessEvents() override;
 
 private:
     NSWindow* _window;

--- a/include/pangolin/display/device/WinWindow.h
+++ b/include/pangolin/display/device/WinWindow.h
@@ -49,17 +49,17 @@ struct WinWindow : public PangolinGl
 
     void StopFullScreen();
 
-    void ToggleFullscreen() PANGOLIN_OVERRIDE;
+    void ToggleFullscreen() override;
 
-    void Move(int x, int y) PANGOLIN_OVERRIDE;
+    void Move(int x, int y) override;
 
-    void Resize(unsigned int w, unsigned int h) PANGOLIN_OVERRIDE;
+    void Resize(unsigned int w, unsigned int h) override;
 
-    void MakeCurrent() PANGOLIN_OVERRIDE;
+    void MakeCurrent() override;
 
-    void SwapBuffers() PANGOLIN_OVERRIDE;
+    void SwapBuffers() override;
 
-    void ProcessEvents() PANGOLIN_OVERRIDE;
+    void ProcessEvents() override;
 
     HGLRC GetGLRenderContext()
     {

--- a/include/pangolin/display/device/X11Window.h
+++ b/include/pangolin/display/device/X11Window.h
@@ -79,19 +79,19 @@ struct X11Window : public PangolinGl
 
     ~X11Window();
 
-    void ToggleFullscreen() PANGOLIN_OVERRIDE;
+    void ToggleFullscreen() override;
 
-    void Move(int x, int y) PANGOLIN_OVERRIDE;
+    void Move(int x, int y) override;
 
-    void Resize(unsigned int w, unsigned int h) PANGOLIN_OVERRIDE;
+    void Resize(unsigned int w, unsigned int h) override;
 
     void MakeCurrent(GLXContext ctx);
 
-    void MakeCurrent() PANGOLIN_OVERRIDE;
+    void MakeCurrent() override;
 
-    void SwapBuffers() PANGOLIN_OVERRIDE;
+    void SwapBuffers() override;
 
-    void ProcessEvents() PANGOLIN_OVERRIDE;
+    void ProcessEvents() override;
 
     // References the X11 display and context.
     std::shared_ptr<X11Display> display;

--- a/include/pangolin/display/display_internal.h
+++ b/include/pangolin/display/display_internal.h
@@ -97,27 +97,27 @@ struct PANGOLIN_EXPORT PangolinGl : public WindowInterface
 
     std::shared_ptr<GlFont> font;
 
-    virtual void ToggleFullscreen() PANGOLIN_OVERRIDE {
+    virtual void ToggleFullscreen() override {
         pango_print_warn("ToggleFullscreen: Not available with non-pangolin window.\n");
     }
 
-    virtual void ProcessEvents() PANGOLIN_OVERRIDE {
+    virtual void ProcessEvents() override {
         pango_print_warn("ProcessEvents: Not available with non-pangolin window.\n");
     }
 
-    virtual void SwapBuffers() PANGOLIN_OVERRIDE {
+    virtual void SwapBuffers() override {
         pango_print_warn("SwapBuffers: Not available with non-pangolin window.\n");
     }
 
-    virtual void MakeCurrent() PANGOLIN_OVERRIDE {
+    virtual void MakeCurrent() override {
         pango_print_warn("MakeCurrent: Not available with non-pangolin window.\n");
     }
 
-    virtual void Move(int /*x*/, int /*y*/) PANGOLIN_OVERRIDE {
+    virtual void Move(int /*x*/, int /*y*/) override {
         pango_print_warn("Move: Not available with non-pangolin window.\n");
     }
 
-    virtual void Resize(unsigned int /*w*/, unsigned int /*h*/) PANGOLIN_OVERRIDE {
+    virtual void Resize(unsigned int /*w*/, unsigned int /*h*/) override {
         pango_print_warn("Resize: Not available with non-pangolin window.\n");
     }
 

--- a/include/pangolin/gl/glcuda.h
+++ b/include/pangolin/gl/glcuda.h
@@ -72,7 +72,7 @@ struct GlTextureCudaArray : GlTexture
     GlTextureCudaArray(int width, int height, GLint internal_format, bool sampling_linear = true, int border = 0, GLenum glformat = GL_RGBA, GLenum gltype = GL_UNSIGNED_BYTE, GLvoid* data = NULL);
     ~GlTextureCudaArray();
 
-    void Reinitialise(int width, int height, GLint internal_format, bool sampling_linear = true, int border = 0, GLenum glformat = GL_RGBA, GLenum gltype = GL_UNSIGNED_BYTE, GLvoid* data = NULL) PANGOLIN_OVERRIDE;
+    void Reinitialise(int width, int height, GLint internal_format, bool sampling_linear = true, int border = 0, GLenum glformat = GL_RGBA, GLenum gltype = GL_UNSIGNED_BYTE, GLvoid* data = NULL) override;
     cudaGraphicsResource* cuda_res;
 };
 

--- a/include/pangolin/handler/handler_image.h
+++ b/include/pangolin/handler/handler_image.h
@@ -115,15 +115,15 @@ public:
     /// pangolin::Handler
     ///////////////////////////////////////////////////////
 
-    void Keyboard(View&, unsigned char key, int /*x*/, int /*y*/, bool pressed) PANGOLIN_OVERRIDE;
+    void Keyboard(View&, unsigned char key, int /*x*/, int /*y*/, bool pressed) override;
 
-    void Mouse(View& view, pangolin::MouseButton button, int x, int y, bool pressed, int button_state) PANGOLIN_OVERRIDE;
+    void Mouse(View& view, pangolin::MouseButton button, int x, int y, bool pressed, int button_state) override;
 
-    void MouseMotion(View& view, int x, int y, int button_state) PANGOLIN_OVERRIDE;
+    void MouseMotion(View& view, int x, int y, int button_state) override;
 
-    void PassiveMouseMotion(View&, int /*x*/, int /*y*/, int /*button_state*/) PANGOLIN_OVERRIDE;
+    void PassiveMouseMotion(View&, int /*x*/, int /*y*/, int /*button_state*/) override;
 
-    void Special(View& view, pangolin::InputSpecial inType, float x, float y, float p1, float p2, float /*p3*/, float /*p4*/, int /*button_state*/) PANGOLIN_OVERRIDE;
+    void Special(View& view, pangolin::InputSpecial inType, float x, float y, float p1, float p2, float /*p3*/, float /*p4*/, int /*button_state*/) override;
 
     ///////////////////////////////////////////////////////
     /// Callbacks

--- a/include/pangolin/platform.h
+++ b/include/pangolin/platform.h
@@ -40,12 +40,6 @@
 #  define PANGOLIN_DEPRECATED
 #endif
 
-#if (__cplusplus > 199711L) || (_MSC_VER >= 1700)
-#  define PANGOLIN_OVERRIDE override
-#else
-#  define PANGOLIN_OVERRIDE
-#endif
-
 #ifdef _MSVC_
 #   define __thread __declspec(thread)
 #   include <pangolin/pangolin_export.h>

--- a/include/pangolin/python/PyInterpreter.h
+++ b/include/pangolin/python/PyInterpreter.h
@@ -43,15 +43,15 @@ class PyInterpreter : public ConsoleInterpreter
 public:
     PyInterpreter();
 
-    ~PyInterpreter() PANGOLIN_OVERRIDE;
+    ~PyInterpreter() override;
 
-    void PushCommand(const std::string &cmd) PANGOLIN_OVERRIDE;
+    void PushCommand(const std::string &cmd) override;
 
-    bool PullLine(ConsoleLine& line) PANGOLIN_OVERRIDE;
+    bool PullLine(ConsoleLine& line) override;
 
     std::vector<std::string> Complete(
         const std::string& cmd, int max_options
-    ) PANGOLIN_OVERRIDE;
+    ) override;
 
     static void AttachPrefix(void* data, const std::string& name, VarValueGeneric& var, bool brand_new );
 

--- a/include/pangolin/utils/threadedfilebuf.h
+++ b/include/pangolin/utils/threadedfilebuf.h
@@ -56,15 +56,15 @@ protected:
     void soft_close();
 
     //! Override streambuf::xsputn for asynchronous write
-    std::streamsize xsputn(const char * s, std::streamsize n) PANGOLIN_OVERRIDE;
+    std::streamsize xsputn(const char * s, std::streamsize n) override;
 
     //! Override streambuf::overflow for asynchronous write
-    int overflow(int c) PANGOLIN_OVERRIDE;
+    int overflow(int c) override;
 
     std::streampos seekoff(
         std::streamoff off, std::ios_base::seekdir way,
         std::ios_base::openmode which = std::ios_base::in | std::ios_base::out
-    ) PANGOLIN_OVERRIDE;
+    ) override;
     
     std::filebuf file;
     char* mem_buffer;

--- a/include/pangolin/video/drivers/images.h
+++ b/include/pangolin/video/drivers/images.h
@@ -49,30 +49,30 @@ public:
     // Implement VideoInterface
     
     //! Implement VideoInput::Start()
-    void Start() PANGOLIN_OVERRIDE;
+    void Start() override;
     
     //! Implement VideoInput::Stop()
-    void Stop() PANGOLIN_OVERRIDE;
+    void Stop() override;
 
     //! Implement VideoInput::SizeBytes()
-    size_t SizeBytes() const PANGOLIN_OVERRIDE;
+    size_t SizeBytes() const override;
 
     //! Implement VideoInput::Streams()
-    const std::vector<StreamInfo>& Streams() const PANGOLIN_OVERRIDE;
+    const std::vector<StreamInfo>& Streams() const override;
     
     //! Implement VideoInput::GrabNext()
-    bool GrabNext( unsigned char* image, bool wait = true ) PANGOLIN_OVERRIDE;
+    bool GrabNext( unsigned char* image, bool wait = true ) override;
     
     //! Implement VideoInput::GrabNewest()
-    bool GrabNewest( unsigned char* image, bool wait = true ) PANGOLIN_OVERRIDE;
+    bool GrabNewest( unsigned char* image, bool wait = true ) override;
 
     // Implement VideoPlaybackInterface
 
-    int GetCurrentFrameId() const PANGOLIN_OVERRIDE;
+    int GetCurrentFrameId() const override;
 
-    int GetTotalFrames() const PANGOLIN_OVERRIDE;
+    int GetTotalFrames() const override;
 
-    int Seek(int frameid) PANGOLIN_OVERRIDE;
+    int Seek(int frameid) override;
     
 protected:
     typedef std::vector<TypedImage> Frame;

--- a/include/pangolin/video/drivers/pango.h
+++ b/include/pangolin/video/drivers/pango.h
@@ -42,32 +42,32 @@ public:
 
     // Implement VideoInterface
 
-    size_t SizeBytes() const PANGOLIN_OVERRIDE;
+    size_t SizeBytes() const override;
 
-    const std::vector<StreamInfo>& Streams() const PANGOLIN_OVERRIDE;
+    const std::vector<StreamInfo>& Streams() const override;
 
-    void Start() PANGOLIN_OVERRIDE;
+    void Start() override;
 
-    void Stop() PANGOLIN_OVERRIDE;
+    void Stop() override;
 
-    bool GrabNext( unsigned char* image, bool wait = true ) PANGOLIN_OVERRIDE;
+    bool GrabNext( unsigned char* image, bool wait = true ) override;
 
-    bool GrabNewest( unsigned char* image, bool wait = true ) PANGOLIN_OVERRIDE;
+    bool GrabNewest( unsigned char* image, bool wait = true ) override;
 
     // Implement VideoPropertiesInterface
 
-    const json::value& DeviceProperties() const PANGOLIN_OVERRIDE;
+    const json::value& DeviceProperties() const override;
 
-    const json::value& FrameProperties() const PANGOLIN_OVERRIDE;
+    const json::value& FrameProperties() const override;
 
 
     // Implement VideoPlaybackInterface
 
-    int GetCurrentFrameId() const PANGOLIN_OVERRIDE;
+    int GetCurrentFrameId() const override;
 
-    int GetTotalFrames() const PANGOLIN_OVERRIDE;
+    int GetTotalFrames() const override;
 
-    int Seek(int frameid) PANGOLIN_OVERRIDE;
+    int Seek(int frameid) override;
 
 private:
     void HandlePipeClosed();

--- a/include/pangolin/video/drivers/pango_video_output.h
+++ b/include/pangolin/video/drivers/pango_video_output.h
@@ -39,10 +39,10 @@ public:
     PangoVideoOutput(const std::string& filename, size_t buffer_size_bytes = 100*1024*1024);
     ~PangoVideoOutput();
 
-    const std::vector<StreamInfo>& Streams() const PANGOLIN_OVERRIDE;
-    void SetStreams(const std::vector<StreamInfo>& streams, const std::string& uri, const json::value& device_properties) PANGOLIN_OVERRIDE;
-    int WriteStreams(const unsigned char* data, const json::value& frame_properties) PANGOLIN_OVERRIDE;
-    bool IsPipe() const PANGOLIN_OVERRIDE;
+    const std::vector<StreamInfo>& Streams() const override;
+    void SetStreams(const std::vector<StreamInfo>& streams, const std::string& uri, const json::value& device_properties) override;
+    int WriteStreams(const unsigned char* data, const json::value& frame_properties) override;
+    bool IsPipe() const override;
 
 protected:
     void WriteHeader();

--- a/include/pangolin/video/video_output.h
+++ b/include/pangolin/video/video_output.h
@@ -75,13 +75,13 @@ public:
     void Open(const std::string& uri);
     void Close();
 
-    const std::vector<StreamInfo>& Streams() const;
+    const std::vector<StreamInfo>& Streams() const override;
 
-    void SetStreams(const std::vector<StreamInfo>& streams, const std::string& uri = "", const json::value& properties = json::value() );
+    void SetStreams(const std::vector<StreamInfo>& streams, const std::string& uri = "", const json::value& properties = json::value() ) override;
 
     int WriteStreams(const unsigned char* data, const json::value& frame_properties = json::value() ) override;
     
-    bool IsPipe() const;
+    bool IsPipe() const override;
 
 protected:
     Uri uri;

--- a/include/pangolin/video/video_record_repeat.h
+++ b/include/pangolin/video/video_record_repeat.h
@@ -41,18 +41,18 @@ struct PANGOLIN_EXPORT VideoRecordRepeat
     // VideoInterface Methods
     /////////////////////////////////////////////////////////////
 
-    size_t SizeBytes() const PANGOLIN_OVERRIDE;
-    const std::vector<StreamInfo>& Streams() const PANGOLIN_OVERRIDE;
-    void Start() PANGOLIN_OVERRIDE;
-    void Stop() PANGOLIN_OVERRIDE;
-    bool GrabNext( unsigned char* image, bool wait = true ) PANGOLIN_OVERRIDE;
-    bool GrabNewest( unsigned char* image, bool wait = true ) PANGOLIN_OVERRIDE;
+    size_t SizeBytes() const override;
+    const std::vector<StreamInfo>& Streams() const override;
+    void Start() override;
+    void Stop() override;
+    bool GrabNext( unsigned char* image, bool wait = true ) override;
+    bool GrabNewest( unsigned char* image, bool wait = true ) override;
 
     /////////////////////////////////////////////////////////////
     // VideoFilterInterface Methods
     /////////////////////////////////////////////////////////////
 
-    std::vector<VideoInterface*>& InputStreams() PANGOLIN_OVERRIDE
+    std::vector<VideoInterface*>& InputStreams() override
     {
         return videos;
     }

--- a/src/display/device/PangolinNSApplication.mm
+++ b/src/display/device/PangolinNSApplication.mm
@@ -25,6 +25,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <pangolin/platform.h>
 #include <pangolin/display/display.h>
 #include <pangolin/display/device/PangolinNSApplication.h>
 
@@ -68,6 +69,8 @@
 @implementation PangolinWindowDelegate
 
 - (BOOL)windowShouldClose:(id)sender {
+    PANGOLIN_UNUSED(sender);
+    
     pangolin::Quit();
     return YES;
 }

--- a/src/display/device/PangolinNSGLView.mm
+++ b/src/display/device/PangolinNSGLView.mm
@@ -1,3 +1,4 @@
+#include <pangolin/platform.h>
 #include <pangolin/gl/glinclude.h>
 #include <pangolin/display/device/PangolinNSGLView.h>
 #include <pangolin/display/display.h>
@@ -299,10 +300,12 @@ int mapKeymap(int osx_key)
 
 - (void)mouseEntered: (NSEvent *)theEvent
 {
+    PANGOLIN_UNUSED(theEvent);
 }
 
 - (void)mouseExited: (NSEvent *)theEvent
 {
+    PANGOLIN_UNUSED(theEvent);
 }
 
 -(void)dealloc

--- a/src/display/device/display_osx.mm
+++ b/src/display/device/display_osx.mm
@@ -184,12 +184,12 @@ void OsxWindow::ToggleFullscreen()
     PangolinGl::is_fullscreen = !PangolinGl::is_fullscreen;
 }
 
-void OsxWindow::Move(int x, int y)
+void OsxWindow::Move(int /*x*/, int /*y*/)
 {
 
 }
 
-void OsxWindow::Resize(unsigned int w, unsigned int h)
+void OsxWindow::Resize(unsigned int /*w*/, unsigned int /*h*/)
 {
 
 }


### PR DESCRIPTION
Because Pangolin now requires C++11, I observed that we can drop the `PANGOLIN_OVERRIDE` macro and use `override` directly as is done by some files already. The other two commits fix some warnings I encountered in the logs of Travis related to the OSX builds.