### PR TITLE
OpenNI2 cropping

### DIFF
--- a/include/pangolin/video/drivers/openni2.h
+++ b/include/pangolin/video/drivers/openni2.h
@@ -45,7 +45,7 @@ struct OpenNi2Video : public VideoInterface, public VideoPropertiesInterface, pu
 public:
 
     // Open all RGB and Depth streams from all devices
-    OpenNi2Video(ImageDim dim=ImageDim(640,480), int fps=30);
+    OpenNi2Video(ImageDim dim=ImageDim(640,480), ImageRoi roi=ImageRoi(0,0,0,0), int fps=30);
 
     // Open streams specified
     OpenNi2Video(std::vector<OpenNiStreamMode>& stream_modes);
@@ -64,6 +64,7 @@ public:
     void SetDepthCloseRange(bool enable);
     void SetDepthHoleFilter(bool enable);
     void SetDepthColorSyncEnabled(bool enable);
+    void SetFastCrop(bool enable);
     void SetRegisterDepthToImage(bool enable);
     void SetPlaybackSpeed(float speed);
     void SetPlaybackRepeat(bool enabled);

--- a/include/pangolin/video/drivers/openni_common.h
+++ b/include/pangolin/video/drivers/openni_common.h
@@ -53,15 +53,16 @@ struct PANGOLIN_EXPORT OpenNiStreamMode
 {
     OpenNiStreamMode(
         OpenNiSensorType sensor_type=OpenNiUnassigned,
-        ImageDim dim=ImageDim(640,480), int fps=30, int device=0
+        ImageDim dim=ImageDim(640,480), ImageRoi roi=ImageRoi(0,0,0,0), int fps=30, int device=0
     )
-        : sensor_type(sensor_type), dim(dim), fps(fps), device(device)
+        : sensor_type(sensor_type), dim(dim), roi(roi), fps(fps), device(device)
     {
 
     }
 
     OpenNiSensorType sensor_type;
     ImageDim dim;
+    ImageRoi roi;
     int fps;
     int device;
 };
@@ -125,7 +126,7 @@ inline std::istream& operator>> (std::istream &is, OpenNiStreamMode& fmt)
     std::string str;
     is >> str;
 
-    std::map<char,std::string> splits = GetTokenSplits(str, "!:@");
+    std::map<char,std::string> splits = GetTokenSplits(str, "!:@#");
 
     if(splits.count(0)) {
         fmt.sensor_type = openni_sensor(splits[0]);
@@ -141,6 +142,10 @@ inline std::istream& operator>> (std::istream &is, OpenNiStreamMode& fmt)
 
     if(splits.count('!')) {
         fmt.device = pangolin::Convert<int,std::string>::Do(splits['!']);
+    }
+
+    if(splits.count('#')) {
+        fmt.roi = pangolin::Convert<ImageRoi,std::string>::Do(splits['#']);
     }
 
     return is;


### PR DESCRIPTION
added cropping to OpenNI2 driver and added option for turning on fast crop mode.

with this change, a crop of an OpenNI2 stream is taken by adding the symbol '#' to the stream string followed by an ImageRoi of the form X+Y+WxH. the fast cropping mode can be activated with the option 'fastcrop'. for example:

openni2:[img1=depth:640x480@30,img2=rgb:1280x1024@30#320+240+640x480,fastcrop=true,framesync=true]//
