### PR TITLE
Fixing Issue #183 Compilation Problems

### DIFF
--- a/src/video/drivers/ffmpeg.cpp
+++ b/src/video/drivers/ffmpeg.cpp
@@ -25,6 +25,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <array>
 #include <pangolin/video/drivers/ffmpeg.h>
 #include <pangolin/factory/factory_registry.h>
 #include <pangolin/video/iostream_operators.h>


### PR DESCRIPTION
On Mac, it's necessary to add the include for the array template type.