### PR TITLE
Fix librealsense include path finding

### DIFF
--- a/CMakeModules/FindLibRealSense.cmake
+++ b/CMakeModules/FindLibRealSense.cmake
@@ -16,9 +16,8 @@ if(${CMAKE_VERSION} VERSION_LESS 2.8.2)
 endif()
 
 #add a hint so that it can find it without the pkg-config
-find_path(LIBREALSENSE_INCLUDE_DIR rs.h
-    HINTS /usr/include/  /usr/local/include
-    PATH_SUFFIXES librealsense)
+find_path(LIBREALSENSE_INCLUDE_DIR librealsense/rs.h
+    HINTS /usr/include/  /usr/local/include)
 #add a hint so that it can find it without the pkg-config
 find_library(LIBREALSENSE_LIBRARY
     NAMES librealsense.so


### PR DESCRIPTION
In code it's #include <librealsense/rs.hpp> but in CMake the path with subdir librealsense is saved. So if the upper dir is not added by others (/usr/local/include or any non-default path that librealsense was installed in), the compile will fail.