### PR TITLE
Fix Appveyor warnings

### DIFF
--- a/examples/SimplePlot/main.cpp
+++ b/examples/SimplePlot/main.cpp
@@ -25,9 +25,9 @@ int main(/*int argc, char* argv[]*/)
   plotter.Track("$i");
 
   // Add some sample annotations to the plot
-  plotter.AddMarker(pangolin::Marker::Vertical,   -1000, pangolin::Marker::LessThan, pangolin::Colour::Blue().WithAlpha(0.2) );
-  plotter.AddMarker(pangolin::Marker::Horizontal,   100, pangolin::Marker::GreaterThan, pangolin::Colour::Red().WithAlpha(0.2) );
-  plotter.AddMarker(pangolin::Marker::Horizontal,    10, pangolin::Marker::Equal, pangolin::Colour::Green().WithAlpha(0.2) );
+  plotter.AddMarker(pangolin::Marker::Vertical,   -1000, pangolin::Marker::LessThan, pangolin::Colour::Blue().WithAlpha(0.2f) );
+  plotter.AddMarker(pangolin::Marker::Horizontal,   100, pangolin::Marker::GreaterThan, pangolin::Colour::Red().WithAlpha(0.2f) );
+  plotter.AddMarker(pangolin::Marker::Horizontal,    10, pangolin::Marker::Equal, pangolin::Colour::Green().WithAlpha(0.2f) );
 
   pangolin::DisplayBase().AddDisplay(plotter);
 

--- a/include/pangolin/gl/colour.h
+++ b/include/pangolin/gl/colour.h
@@ -61,12 +61,12 @@ struct Colour
 
     /// Default constructs white.
     inline Colour()
-        : red(1.0), green(1.0), blue(1.0), alpha(1.0)
+        : red(1.0f), green(1.0f), blue(1.0f), alpha(1.0f)
     {
     }
 
     /// Construct from component values
-    inline Colour(float red, float green, float blue, float alpha = 1.0)
+    inline Colour(float red, float green, float blue, float alpha = 1.0f)
         : red(red), green(green), blue(blue), alpha(alpha)
     {
     }
@@ -96,7 +96,7 @@ struct Colour
     /// @param hue Colour hue in range [0,1]
     /// @param sat Saturation in range [0,1]
     /// @param val Value / Brightness in range [0,1].
-    static inline Colour Hsv(float hue, float sat = 1.0, float val = 1.0, float alpha = 1.0)
+    static inline Colour Hsv(float hue, float sat = 1.0f, float val = 1.0f, float alpha = 1.0f)
     {
           const float h = 6.0f * hue;
           const int i = (int)floor(h);
@@ -143,7 +143,7 @@ class ColourWheel
 {
 public:
     /// Construct ColourWheel with Saturation, Value and Alpha constant.
-    inline ColourWheel(float saturation=0.5, float value=1.0, float alpha = 1.0)
+    inline ColourWheel(float saturation = 0.5f, float value = 1.0f, float alpha = 1.0f)
         : unique_colours(0), sat(saturation), val(value), alpha(alpha)
     {
 

--- a/include/pangolin/image/managed_image.h
+++ b/include/pangolin/image/managed_image.h
@@ -54,7 +54,7 @@ public:
 
     // Row image
     inline
-    ManagedImage(unsigned int w)
+    ManagedImage(size_t w)
         : Image<T>(
               Allocator().allocate(w),
                w, 1, w*sizeof(T)
@@ -63,7 +63,7 @@ public:
     }
 
     inline
-    ManagedImage(unsigned int w, unsigned int h)
+    ManagedImage(size_t w, size_t h)
         : Image<T>(
               Allocator().allocate(w*h),
                w, h, w*sizeof(T)
@@ -72,7 +72,7 @@ public:
     }
 
     inline
-    ManagedImage(unsigned int w, unsigned int h, unsigned int pitch_bytes)
+    ManagedImage(size_t w, size_t h, size_t pitch_bytes)
         : Image<T>(
               Allocator().allocate( (h*pitch_bytes) / sizeof(T) + 1),
                w, h, w*sizeof(T)
@@ -136,7 +136,7 @@ public:
     }
 
     inline
-    void Reinitialise(unsigned int w, unsigned int h)
+    void Reinitialise(size_t w, size_t h)
     {
         if(!Image<T>::ptr || Image<T>::w != w || Image<T>::h != h) {
             *this = ManagedImage<T,Allocator>(w,h);
@@ -144,7 +144,7 @@ public:
     }
 
     inline
-    void Reinitialise(unsigned int w, unsigned int h, unsigned int pitch)
+    void Reinitialise(size_t w, size_t h, size_t pitch)
     {
         if(!Image<T>::ptr || Image<T>::w != w || Image<T>::h != h || Image<T>::pitch != pitch) {
             *this = ManagedImage<T,Allocator>(w,h,pitch);

--- a/include/pangolin/image/typed_image.h
+++ b/include/pangolin/image/typed_image.h
@@ -41,25 +41,25 @@ struct TypedImage : public ManagedImage<unsigned char>
     {
     }
 
-    inline TypedImage(unsigned int w, unsigned int h, const PixelFormat& fmt)
+    inline TypedImage(size_t w, size_t h, const PixelFormat& fmt)
         : ManagedImage<unsigned char>(w,h,w*fmt.bpp/8), fmt(fmt)
     {
     }
 
-    inline TypedImage(unsigned int w, unsigned int h, const PixelFormat& fmt, size_t pitch )
+    inline TypedImage(size_t w, size_t h, const PixelFormat& fmt, size_t pitch )
         : Base(w,h, pitch), fmt(fmt)
     {
     }
 
     inline
-    void Reinitialise(unsigned int w, unsigned int h, const PixelFormat& fmt)
+    void Reinitialise(size_t w, size_t h, const PixelFormat& fmt)
     {
         Base::Reinitialise(w, h, w*fmt.bpp/8);
         this->fmt = fmt;
     }
 
     inline
-    void Reinitialise(unsigned int w, unsigned int h, const PixelFormat& fmt, size_t pitch)
+    void Reinitialise(size_t w, size_t h, const PixelFormat& fmt, size_t pitch)
     {
         Base::Reinitialise(w, h, pitch);
         this->fmt = fmt;

--- a/include/pangolin/video/drivers/merge.h
+++ b/include/pangolin/video/drivers/merge.h
@@ -38,7 +38,7 @@ namespace pangolin
 class PANGOLIN_EXPORT MergeVideo : public VideoInterface, public VideoFilterInterface
 {
 public:
-    MergeVideo(std::unique_ptr<VideoInterface>& src, const std::vector<Point>& stream_pos , int w, int h);
+    MergeVideo(std::unique_ptr<VideoInterface>& src, const std::vector<Point>& stream_pos, size_t w, size_t h);
     ~MergeVideo();
     
     void Start() override;

--- a/src/video/drivers/merge.cpp
+++ b/src/video/drivers/merge.cpp
@@ -36,7 +36,7 @@
 namespace pangolin
 {
 
-MergeVideo::MergeVideo(std::unique_ptr<VideoInterface>& src_, const std::vector<Point>& stream_pos, int w = 0, int h = 0 )
+MergeVideo::MergeVideo(std::unique_ptr<VideoInterface>& src_, const std::vector<Point>& stream_pos, size_t w = 0, size_t h = 0 )
     : src( std::move(src_) ), buffer(new uint8_t[src->SizeBytes()]), stream_pos(stream_pos)
 {
     videoin.push_back(src.get());
@@ -51,12 +51,12 @@ MergeVideo::MergeVideo(std::unique_ptr<VideoInterface>& src_, const std::vector<
     }
 
     // Compute buffer regions for data copying.
-    XYRangei r = XYRangei::Empty();
+    XYRange<size_t> r = XYRange<size_t>::Empty();
     for(size_t i=0; i < src->Streams().size(); ++i) {
         const StreamInfo& si = src->Streams()[i];
-        const int x = stream_pos[i].x;
-        const int y = stream_pos[i].y;
-        XYRangei sr(x, x + si.Width(), y, y + si.Height());
+        const size_t x = stream_pos[i].x;
+        const size_t y = stream_pos[i].y;
+        XYRange<size_t> sr(x, x + si.Width(), y, y + si.Height());
         r.Insert(sr);
     }
 


### PR DESCRIPTION
I've found these warnings in the Appveyor log. The `size_t -> int` warning might be critical if the user tries to pass negative numbers. The `double -> float` warning is less problematic, but should be fixed too.