### PR TITLE
Compile Error Fix

### DIFF
--- a/include/pangolin/video/drivers/realsense.h
+++ b/include/pangolin/video/drivers/realsense.h
@@ -4,6 +4,8 @@
 
 #include <pangolin/video/video.h>
 
+#include <pangolin/video/iostream_operators.h>
+
 namespace rs {
 class context;
 class device;

--- a/src/video/drivers/realsense.cpp
+++ b/src/video/drivers/realsense.cpp
@@ -1,7 +1,6 @@
 #include <librealsense/rs.hpp>
 #include <pangolin/video/drivers/realsense.h>
 #include <pangolin/factory/factory_registry.h>
-#include <pangolin/video/iostream_operators.h>
 
 namespace pangolin {
 


### PR DESCRIPTION
My first pull request in github. Hope its usefull. 
Just fixing a little bug which leads to this compile error:
realsense.h:81:5: error: ‘ImageDim’ does not name a type
     ImageDim  dim_;