### PR TITLE
Fixed link errors when video support is disabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -237,6 +237,10 @@ endif()
 if(UNIX)
   append_glob(HEADERS ${INCDIR}/utils/posix/*.h*)
   append_glob(SOURCES utils/posix/*.cpp)
+  if(_LINUX_)
+    # Required for shared memory API using some versions of glibc
+    list(APPEND LINK_LIBS rt pthread)
+  endif()
 endif()
 
 find_package(PythonLibs QUIET)

--- a/src/display/view.cpp
+++ b/src/display/view.cpp
@@ -500,6 +500,8 @@ void View::SaveOnRender(const std::string& filename_prefix)
 
 void View::RecordOnRender(const std::string& record_uri)
 {
+    PANGOLIN_UNUSED(record_uri);
+    
 #ifdef BUILD_PANGOLIN_VIDEO
     if(!context->recorder.IsOpen()) {
         Viewport area = GetBounds();

--- a/src/image/image_io.cpp
+++ b/src/image/image_io.cpp
@@ -28,8 +28,10 @@
 #include <pangolin/platform.h>
 
 #include <pangolin/image/image_io.h>
-#include <pangolin/video/drivers/pango.h>
-#include <pangolin/video/drivers/pango_video_output.h>
+#ifdef BUILD_PANGOLIN_VIDEO
+#  include <pangolin/video/drivers/pango.h>
+#  include <pangolin/video/drivers/pango_video_output.h>
+#endif
 
 #include <algorithm>
 #include <stdexcept>
@@ -90,6 +92,9 @@ PixelFormat TgaFormat(int depth, int color_type, int color_map)
 
 TypedImage LoadFromVideo(const std::string& uri)
 {
+    PANGOLIN_UNUSED(uri);
+    
+#ifdef BUILD_PANGOLIN_VIDEO
     std::unique_ptr<VideoInterface> video = OpenVideo(uri);
     if(!video || video->Streams().size() != 1) {
         throw pangolin::VideoException("Wrong number of streams: exactly one expected.");
@@ -114,14 +119,25 @@ TypedImage LoadFromVideo(const std::string& uri)
     }
 
     return image;
+#else   
+    throw std::runtime_error("Video Support not enabled. Please rebuild Pangolin.");
+#endif
 }
 
 void SaveToVideo(const Image<unsigned char>& image, const pangolin::PixelFormat& fmt, const std::string& uri, bool /*top_line_first*/)
 {
+    PANGOLIN_UNUSED(image);
+    PANGOLIN_UNUSED(fmt);
+    PANGOLIN_UNUSED(uri);
+
+#ifdef BUILD_PANGOLIN_VIDEO
     std::unique_ptr<VideoOutputInterface> video = OpenVideoOutput(uri);
     StreamInfo stream(fmt, image.w, image.h, image.pitch);
     video->SetStreams({stream});
     video->WriteStreams(image.ptr);
+#else   
+    throw std::runtime_error("Video Support not enabled. Please rebuild Pangolin.");
+#endif
 }
 
 TypedImage LoadTga(const std::string& filename)


### PR DESCRIPTION
Hi,

This PR fixes some link errors when `BUILD_PANGOLIN_VIDEO` is turned off.

Kind regards,
Patrick