### PR TITLE
Fix msvc14 shared library build.

### DIFF
--- a/include/pangolin/tools/video_viewer.h
+++ b/include/pangolin/tools/video_viewer.h
@@ -1,8 +1,9 @@
+#include <pangolin/platform.h>
 #include <string>
 
 namespace pangolin
 {
 
-void RunVideoViewerUI(const std::string& input_uri, const std::string& output_uri);
+void PANGOLIN_EXPORT RunVideoViewerUI(const std::string& input_uri, const std::string& output_uri);
 
 }

--- a/include/pangolin/video/drivers/images.h
+++ b/include/pangolin/video/drivers/images.h
@@ -44,6 +44,12 @@ public:
     ImagesVideo(const std::string& wildcard_path);
     ImagesVideo(const std::string& wildcard_path, const PixelFormat& raw_fmt, size_t raw_width, size_t raw_height);
 
+    // Explicitly delete copy ctor and assignment operator.
+    // See http://stackoverflow.com/questions/29565299/how-to-use-a-vector-of-unique-pointers-in-a-dll-exported-class-with-visual-studi
+    // >> It appears adding __declspec(dllexport) forces the compiler to define the implicitly-declared copy constructor and copy assignment operator
+    ImagesVideo(const ImagesVideo&) = delete;
+    ImagesVideo& operator=(const ImagesVideo&) = delete;
+
     ~ImagesVideo();
 
     // Implement VideoInterface

--- a/include/pangolin/video/drivers/join.h
+++ b/include/pangolin/video/drivers/join.h
@@ -39,6 +39,12 @@ public:
     JoinVideo(std::vector<std::unique_ptr<VideoInterface>> &src);
 
     ~JoinVideo();
+    
+    // Explicitly delete copy ctor and assignment operator.
+    // See http://stackoverflow.com/questions/29565299/how-to-use-a-vector-of-unique-pointers-in-a-dll-exported-class-with-visual-studi
+    // >> It appears adding __declspec(dllexport) forces the compiler to define the implicitly-declared copy constructor and copy assignment operator
+    JoinVideo(const JoinVideo&) = delete;
+    JoinVideo& operator=(const JoinVideo&) = delete;
 
     size_t SizeBytes() const;
 

--- a/src/tools/video_viewer.cpp
+++ b/src/tools/video_viewer.cpp
@@ -37,7 +37,7 @@ void ConvertPixels(pangolin::Image<To>& to, const pangolin::Image<From>& from)
     }
 }
 
-void RunVideoViewerUI(const std::string& input_uri, const std::string& output_uri)
+PANGOLIN_EXPORT void RunVideoViewerUI(const std::string& input_uri, const std::string& output_uri)
 {
 #ifdef _UNIX_
     struct sigaction sigIntHandler;


### PR DESCRIPTION
Add missing export for VideoViewer tool.
Fixes #223.  
There is still a lot of warnings about missing library and `std::` exports.  
I did't change one, because I don't know what do you think about pangolin`s public API.