### PR TITLE
fixing plot issue on windows

### DIFF
--- a/src/plot/plotter.cpp
+++ b/src/plot/plotter.cpp
@@ -427,8 +427,8 @@ void Plotter::Render()
 
     const float min_space = 80.0;
     int ta[2] = {1,1};
-    while(v.w * ta[0] *tick[0].val / w < min_space) ta[0] *=2;
-    while(v.h * ta[1] *tick[1].val / h < min_space) ta[1] *=2;
+    while(v.w != 0 && v.w * ta[0] *tick[0].val / w < min_space) ta[0] *=2;
+    while(v.h != 0 && v.h * ta[1] *tick[1].val / h < min_space) ta[1] *=2;
 
     const float tdelta[2] = {
         tick[0].val * ta[0],


### PR DESCRIPTION
Hey @stevenlovegrove , 
First, awesome tool. I have been using it for a couple months now and it's amazing.

I ran into some issues with the Plotter while on Windows 7. 
Namely, when a plotting view is active and the application window is minimized, the entire window hangs and cannot be brought up again. I tracked it down to [src/plot/plotter.cpp#L430](https://github.com/stevenlovegrove/Pangolin/blob/f695ffd9274c6f2f32d6d6d3f0b563307fc988cc/src/plot/plotter.cpp#L430)

When the window is minimized the viewport width/height are set to zero (at least on windows), so the render code never breaks out of that loop.  If you want to double check the issue, the SimplePlot example has this problem.
 
The proposed solution is simple: only go into the loop if the viewport dimensions are non-zero.
