### PR TITLE
Determine PNG compression level from quality

### DIFF
--- a/src/image/image_io.cpp
+++ b/src/image/image_io.cpp
@@ -104,7 +104,8 @@ void SaveImage(const Image<unsigned char>& image, const pangolin::PixelFormat& f
 {
     switch (file_type) {
     case ImageFileTypePng:
-        return SavePng(image, fmt, out, top_line_first, quality);
+        // map quality [0..100] to PNG compression levels [0..9]
+        return SavePng(image, fmt, out, top_line_first, int(quality*0.09));
     case ImageFileTypeJpg:
         return SaveJpg(image, fmt, out, quality);
     case ImageFileTypePpm:


### PR DESCRIPTION
This commit fixes the PNG export which expects compression levels in the range [0,9] but is called with compression levels in the range [0,100] which causes the exception:
```
libpng error: zlib failed to initialize compressor -- stream error
terminate called after throwing an instance of 'std::runtime_error'
  what():  PNG Error: Error during png creation.
```

The issue can be solved by mapping the image quality to compression levels for PNG export.