### PR TITLE
include definition of Imf::IStream

### DIFF
--- a/src/image/image_io_exr.cpp
+++ b/src/image/image_io_exr.cpp
@@ -7,6 +7,7 @@
 #include <ImfChannelList.h>
 #include <ImfInputFile.h>
 #include <ImfOutputFile.h>
+#include <ImfIO.h>
 #endif // HAVE_OPENEXR
 
 namespace pangolin {


### PR DESCRIPTION
Fixes the missing class definition:
```
Pangolin/src/image/image_io_exr.cpp:35:31: error: invalid use of incomplete type ‘class Imf::IStream’
 class StdIStream: public Imf::IStream
```
