### PR TITLE
Add package.xml for catkin_tools.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>pangolin</name>
+  <version>0.5.0</version>
+  <description>pangolin</description>
+  <maintainer email="stevenlovegrove@gmail.com">Steven Lovegrove</maintainer>
+  <author     email="stevenlovegrove@gmail.com">Steven Lovegrove</author>
+  <license>MIT</license>
+  <buildtool_depend>cmake</buildtool_depend>
+  <depend>libglew-dev</depend>
+  <depend>cmake</depend>
+  <depend>python</depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Not sure if you are willing to include this?

With this, you can build Pangolin as part of a catkin workspace
with catkin_tools. Note that with this, Pangolin is still a pure
cmake package, not a catkin package. For a catkinized pangolin,
see https://github.com/uzh-rpg/pangolin_catkin.

You can test it for example with

```
mkdir -p /tmp/test-ws/src
cd /tmp/test-ws/src
git clone https://github.com/NikolausDemmel/Pangolin
cd /tmp/test-ws
catkin init
catkin build

# now pangolin is installed in /tmp/test-ws/devel and catkin packages in the ROS ws can find_package it.
```

