### PR TITLE
fixed OSX default oversized font problem

### DIFF
--- a/src/display/device/display_osx.mm
+++ b/src/display/device/display_osx.mm
@@ -57,7 +57,7 @@ namespace pangolin
 
 WindowInterface& CreateWindowAndBind(std::string window_title, int w, int h, const Params& params )
 {
-    const bool is_highres = params.Get<bool>(PARAM_HIGHRES, true);
+    const bool is_highres = params.Get<bool>(PARAM_HIGHRES, false);
 
     OsxWindow* win = new OsxWindow(window_title, w, h, is_highres);
 


### PR DESCRIPTION
OSX default font rendering has been a problem for multiple OSX versions, causing the UI panel font to spill over and be unreadable on all the example projects, (on a Thunderbolt display, resolution 2560 x 1440 for instance). This effectively only changes the font height assignment default from 30 to 15, causing fonts to look fine.