### PR TITLE
fix a crash bug for GUI on OSX

### DIFF
--- a/include/pangolin/display/device/PangolinNSApplication.h
+++ b/include/pangolin/display/device/PangolinNSApplication.h
@@ -34,11 +34,11 @@
 // PangolinNSApplication
 ////////////////////////////////////////////////////////////////////
 
-@interface PangolinNSApplication : NSApplication {
+@interface PangolinNSApplication : NSObject {
 }
 
-- (void)run_pre;
-- (void)run_step;
++ (void)run_pre;
++ (void)run_step;
 
 @end
 

--- a/src/display/device/PangolinNSApplication.mm
+++ b/src/display/device/PangolinNSApplication.mm
@@ -35,7 +35,7 @@
 
 @implementation PangolinNSApplication
 
-- (void)run_pre
++ (void)run_pre
 {
     [[NSNotificationCenter defaultCenter]
         postNotificationName:NSApplicationWillFinishLaunchingNotification
@@ -45,18 +45,18 @@
         object:NSApp];
 }
 
-- (void)run_step
++ (void)run_step
 {
     NSEvent *event;
     do{
-        event = [self
+        event = [NSApp
                 nextEventMatchingMask:NSAnyEventMask
                 untilDate:nil
 //                untilDate: [NSDate distantFuture]
                 inMode:NSDefaultRunLoopMode
                 dequeue:YES];
-        [self sendEvent:event];
-        [self updateWindows];
+        [NSApp sendEvent:event];
+        [NSApp updateWindows];
     }while(event != nil);
 }
 

--- a/src/display/device/display_osx.mm
+++ b/src/display/device/display_osx.mm
@@ -85,14 +85,14 @@ OsxWindow::OsxWindow(
     // Make sure Application is initialised correctly.
     // This can be run repeatedly.
 
-    NSApp = [PangolinNSApplication sharedApplication];
+    [NSApplication sharedApplication];
     PangolinAppDelegate *delegate = [[PangolinAppDelegate alloc] init];
 
-    [[PangolinNSApplication sharedApplication] setDelegate:delegate];
-    [[PangolinNSApplication sharedApplication] setPresentationOptions:NSFullScreenWindowMask];
+    [NSApp setDelegate:delegate];
+    [NSApp setPresentationOptions:NSFullScreenWindowMask];
 
-    [NSApp run_pre];
-    [NSApp run_step];
+    [PangolinNSApplication run_pre];
+    [PangolinNSApplication run_step];
 
     ///////////////////////////////////////////////////////////////////////
     // Create Window
@@ -151,7 +151,7 @@ OsxWindow::OsxWindow(
 
     [_window setContentView:view];
 
-    [NSApp run_step];
+    [PangolinNSApplication run_step];
 
     glewInit();
 
@@ -211,7 +211,7 @@ void OsxWindow::SwapBuffers()
 
 void OsxWindow::ProcessEvents()
 {
-    [NSApp run_step];
+    [PangolinNSApplication run_step];
 }
 
 }


### PR DESCRIPTION
The `CreateWindowAndBind` function will cause crash on Mac OSX 10.12.6. This is cased by the member call `run_pre` and `run_step` for subclass `PangolinNSApplication` with base class pointer. As suggested in the [Documents](https://developer.apple.com/documentation/appkit/nsapplication), creating a custom `NSApplication` subclass is disfavor. So I modify them into static member functions.