### PR TITLE
Pass the pressed key to registered callback

### DIFF
--- a/include/pangolin/display/display.h
+++ b/include/pangolin/display/display.h
@@ -117,9 +117,13 @@ namespace pangolin
   void PostRender();
 
   /// Request to be notified via functor when key is pressed.
-  /// Functor may take one parameter which will equal the key pressed
   PANGOLIN_EXPORT
   void RegisterKeyPressCallback(int key, std::function<void(void)> func);
+
+  /// Request to be notified via functor when key is pressed.
+  /// Functor takes one parameter which will equal the key pressed
+  PANGOLIN_EXPORT
+  void RegisterKeyPressCallback(int key, std::function<void(int)> func);
 
   /// Save window contents to image.
   PANGOLIN_EXPORT

--- a/include/pangolin/display/display_internal.h
+++ b/include/pangolin/display/display_internal.h
@@ -53,7 +53,7 @@ class ConsoleView;
 class GlFont;
 
 typedef std::map<const std::string,View*> ViewMap;
-typedef std::map<int,std::function<void(void)> > KeyhookMap;
+typedef std::map<int,std::function<void(int)> > KeyhookMap;
 
 struct PANGOLIN_EXPORT PangolinGl : public WindowInterface
 {

--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -345,9 +345,15 @@ View& Display(const std::string& name)
     }
 }
 
-void RegisterKeyPressCallback(int key, std::function<void(void)> func)
+void RegisterKeyPressCallback(int key, std::function<void(int)> func)
 {
     context->keypress_hooks[key] = func;
+}
+
+void RegisterKeyPressCallback(int key, std::function<void()> func)
+{
+    auto aug_func = [=](int) { func(); };
+    RegisterKeyPressCallback(key, aug_func);
 }
 
 void SaveWindowOnRender(std::string prefix)
@@ -431,7 +437,7 @@ void Keyboard( unsigned char key, int x, int y)
     }else
 #endif
     if(hook != context->keypress_hooks.end() ) {
-        hook->second();
+        hook->second(key);
     } else if(context->activeDisplay && context->activeDisplay->handler) {
         context->activeDisplay->handler->Keyboard(*(context->activeDisplay),key,x,y,true);
     }


### PR DESCRIPTION
The comment above RegisterKeyPressCallback suggests your callback function can take a parameter indicating the pressed key, but it doesn't seem supported. 

This shouldn't break existing code.