### PR TITLE
Fix compilation

### DIFF
--- a/include/pangolin/video/drivers/depthsense.h
+++ b/include/pangolin/video/drivers/depthsense.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <pangolin/pangolin.h>
+#include <pangolin/video/iostream_operators.h>
 #include <pangolin/video/video.h>
 
 #include <thread>


### PR DESCRIPTION
In the latest master (2fda7e4) the following error is happening: 

```
Pangolin/include/pangolin/video/drivers/depthsense.h:55:98: error: ‘ImageDim’ has not been declared
     DepthSenseVideo(DepthSense::Device device, DepthSenseSensorType s1, DepthSenseSensorType s2, ImageDim dim1, ImageDim dim2, unsigned int fps1, unsigned int fps2, const Uri& uri);
```

This PR fixes it.