### PR TITLE
Use target-based include_directories to enable modern CMake usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 project("Pangolin")
 set(PANGOLIN_VERSION_MAJOR 0)
 set(PANGOLIN_VERSION_MINOR 5)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,10 @@ install:
   
 before_build:
   - cd c:/projects/Pangolin
+  - mkdir bin
   - mkdir build
   - cd build
-  - cmake -G "Visual Studio 14 2015 Win64" -D EIGEN3_INCLUDE_DIR=C:/projects/eigen-eigen-b9cd8366d4e8 ..
+  - cmake -G "Visual Studio 14 2015 Win64" -D EIGEN3_INCLUDE_DIR=C:/projects/eigen-eigen-b9cd8366d4e8 -D CMAKE_INSTALL_PREFIX=../bin ..
 
 on_success:
   - 7z a pangolin_build.zip "c:/projects/Pangolin/build/src/include" "c:/projects/Pangolin/build/src/Release/pangolin.lib" "c:/projects/Pangolin/build/tools/*/Release/*.exe" "c:/projects/Pangolin/build/examples/*/Release/*.exe"

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -7,13 +7,12 @@ if( BUILD_EXTERN_GLEW )
 #########################################################
 # GLEW
 #########################################################
-set(glew_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/glew")
 ExternalProject_Add( __glew
-  PREFIX "${glew_PREFIX}"
+  PREFIX "${CMAKE_CURRENT_BINARY_DIR}/glew"
   GIT_REPOSITORY https://github.com/Perlmint/glew-cmake.git
   GIT_TAG 7574ab4d00b683e56adbfdec7da636529dfe65d8
-  INSTALL_DIR ${glew_PREFIX}
-  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${glew_PREFIX}
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
              -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
              -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
              -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
@@ -24,21 +23,21 @@ ExternalProject_Add( __glew
 add_library(_glew STATIC IMPORTED GLOBAL)
 add_dependencies(_glew __glew)
 set_target_properties(_glew PROPERTIES
-    IMPORTED_LOCATION_RELWITHDEBINFO ${glew_PREFIX}/lib/glew.lib
-    IMPORTED_LOCATION_RELEASE ${glew_PREFIX}/lib/glew.lib
-    IMPORTED_LOCATION_DEBUG   ${glew_PREFIX}/lib/glewd.lib
+    IMPORTED_LOCATION_RELWITHDEBINFO ${CMAKE_INSTALL_PREFIX}/lib/glew.lib
+    IMPORTED_LOCATION_RELEASE ${CMAKE_INSTALL_PREFIX}/lib/glew.lib
+    IMPORTED_LOCATION_DEBUG   ${CMAKE_INSTALL_PREFIX}}/lib/glewd.lib
 )
 
 set(GLEW_FOUND true PARENT_SCOPE)
-set(GLEW_INCLUDE_DIR "${glew_PREFIX}/include" PARENT_SCOPE)
+set(GLEW_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include" PARENT_SCOPE)
 set(GLEW_LIBRARY _glew PARENT_SCOPE)
 set(GLEW_STATIC 1 PARENT_SCOPE)
 set(ExternConfig "${ExternConfig}
   add_library(_glew STATIC IMPORTED)
   set_target_properties(_glew PROPERTIES
-    IMPORTED_LOCATION_RELWITHDEBINFO ${glew_PREFIX}/lib/glew.lib
-    IMPORTED_LOCATION_RELEASE ${glew_PREFIX}/lib/glew.lib
-    IMPORTED_LOCATION_DEBUG   ${glew_PREFIX}/lib/glewd.lib
+    IMPORTED_LOCATION_RELWITHDEBINFO ${CMAKE_INSTALL_PREFIX}/lib/glew.lib
+    IMPORTED_LOCATION_RELEASE ${CMAKE_INSTALL_PREFIX}/lib/glew.lib
+    IMPORTED_LOCATION_DEBUG   ${CMAKE_INSTALL_PREFIX}/lib/glewd.lib
   )")
 endif()
 
@@ -48,13 +47,12 @@ if( BUILD_EXTERN_LIBPNG )
 # zlib
 #########################################################
 
-set(zlib_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/zlib")
 ExternalProject_Add( __zlib
-  PREFIX "${zlib_PREFIX}"
+  PREFIX "${CMAKE_CURRENT_BINARY_DIR}/zlib"
   GIT_REPOSITORY https://github.com/madler/zlib.git
   GIT_TAG v1.2.8
-  INSTALL_DIR ${zlib_PREFIX}
-  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${zlib_PREFIX}
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
              -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
              -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
              -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
@@ -64,24 +62,23 @@ ExternalProject_Add( __zlib
 add_library(_zlib STATIC IMPORTED GLOBAL)
 add_dependencies(_zlib __zlib)
 set_target_properties(_zlib PROPERTIES
-    IMPORTED_LOCATION_RELEASE ${zlib_PREFIX}/lib/zlibstatic.lib
-    IMPORTED_LOCATION_RELWITHDEBINFO ${zlib_PREFIX}/lib/zlibstatic.lib
-    IMPORTED_LOCATION_DEBUG   ${zlib_PREFIX}/lib/zlibstaticd.lib
+    IMPORTED_LOCATION_RELEASE ${CMAKE_INSTALL_PREFIX}/lib/zlibstatic.lib
+    IMPORTED_LOCATION_RELWITHDEBINFO ${CMAKE_INSTALL_PREFIX}/lib/zlibstatic.lib
+    IMPORTED_LOCATION_DEBUG   ${CMAKE_INSTALL_PREFIX}/lib/zlibstaticd.lib
 )
 
 #########################################################
 # libpng
 #########################################################
 
-set(libpng_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/libpng")
 ExternalProject_Add( __libpng
-  PREFIX "${libpng_PREFIX}"
+  PREFIX "${CMAKE_CURRENT_BINARY_DIR}/libpng"
   GIT_REPOSITORY https://github.com/glennrp/libpng.git
   GIT_TAG v1.6.18
-  INSTALL_DIR ${libpng_PREFIX}
-  CMAKE_ARGS  -DCMAKE_INSTALL_PREFIX=${libpng_PREFIX}
-              -DZLIB_INCLUDE_DIR=${zlib_PREFIX}/include
-              -DZLIB_LIBRARY=${zlib_PREFIX}/lib/zlibstatic*.lib
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+  CMAKE_ARGS  -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+              -DZLIB_INCLUDE_DIR=${CMAKE_INSTALL_PREFIX}/include
+              -DZLIB_LIBRARY=${CMAKE_INSTALL_PREFIX}/lib/zlibstatic*.lib
               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
               -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
               -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
@@ -93,27 +90,27 @@ ExternalProject_Add( __libpng
 add_library(_libpng STATIC IMPORTED GLOBAL)
 add_dependencies(_libpng __libpng)
 set_target_properties(_libpng PROPERTIES
-    IMPORTED_LOCATION_RELWITHDEBINFO ${libpng_PREFIX}/lib/libpng16_static.lib
-	IMPORTED_LOCATION_RELEASE ${libpng_PREFIX}/lib/libpng16_static.lib
-    IMPORTED_LOCATION_DEBUG   ${libpng_PREFIX}/lib/libpng16_staticd.lib
+    IMPORTED_LOCATION_RELWITHDEBINFO ${CMAKE_INSTALL_PREFIX}/lib/libpng16_static.lib
+	IMPORTED_LOCATION_RELEASE ${CMAKE_INSTALL_PREFIX}/lib/libpng16_static.lib
+    IMPORTED_LOCATION_DEBUG   ${CMAKE_INSTALL_PREFIX}/lib/libpng16_staticd.lib
 )
 
 set(PNG_FOUND true PARENT_SCOPE)
-set(PNG_INCLUDE_DIR "${libpng_PREFIX}/include" PARENT_SCOPE)
+set(PNG_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include" PARENT_SCOPE)
 set(PNG_LIBRARY _libpng PARENT_SCOPE)
 set(ZLIB_LIBRARY _zlib PARENT_SCOPE)
 set(ExternConfig "${ExternConfig}
   add_library(_zlib STATIC IMPORTED)
   set_target_properties(_zlib PROPERTIES
-    IMPORTED_LOCATION_RELEASE ${zlib_PREFIX}/lib/zlibstatic.lib
-    IMPORTED_LOCATION_RELWITHDEBINFO ${zlib_PREFIX}/lib/zlibstatic.lib
-    IMPORTED_LOCATION_DEBUG   ${zlib_PREFIX}/lib/zlibstaticd.lib
+    IMPORTED_LOCATION_RELEASE ${CMAKE_INSTALL_PREFIX}/lib/zlibstatic.lib
+    IMPORTED_LOCATION_RELWITHDEBINFO ${CMAKE_INSTALL_PREFIX}/lib/zlibstatic.lib
+    IMPORTED_LOCATION_DEBUG   ${CMAKE_INSTALL_PREFIX}/lib/zlibstaticd.lib
   )
   add_library(_libpng STATIC IMPORTED)
   set_target_properties(_libpng PROPERTIES
-    IMPORTED_LOCATION_RELEASE ${libpng_PREFIX}/lib/libpng16_static.lib
-    IMPORTED_LOCATION_RELWITHDEBINFO ${libpng_PREFIX}/lib/libpng16_static.lib
-    IMPORTED_LOCATION_DEBUG   ${libpng_PREFIX}/lib/libpng16_staticd.lib
+    IMPORTED_LOCATION_RELEASE ${CMAKE_INSTALL_PREFIX}/lib/libpng16_static.lib
+    IMPORTED_LOCATION_RELWITHDEBINFO ${CMAKE_INSTALL_PREFIX}/lib/libpng16_static.lib
+    IMPORTED_LOCATION_DEBUG   ${CMAKE_INSTALL_PREFIX}/lib/libpng16_staticd.lib
   )")
 endif()
 
@@ -123,13 +120,12 @@ if( BUILD_EXTERN_LIBJPEG )
 # libjpg
 #########################################################
 
-set(libjpeg_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/libjpeg")
 ExternalProject_Add( __libjpeg
-  PREFIX "${libjpeg_PREFIX}"
+  PREFIX "${CMAKE_CURRENT_BINARY_DIR}/libjpeg"
   GIT_REPOSITORY https://github.com/LuaDist/libjpeg.git
   GIT_TAG bc8f8be222287fec977ec3f47a5cb065cceb2ee9
-  INSTALL_DIR ${libjpeg_PREFIX}
-  CMAKE_ARGS  -DCMAKE_INSTALL_PREFIX=${libjpeg_PREFIX}
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+  CMAKE_ARGS  -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
               -DBUILD_SHARED_LIBS=false
               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
               -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
@@ -141,16 +137,16 @@ ExternalProject_Add( __libjpeg
 add_library(_libjpeg STATIC IMPORTED GLOBAL)
 add_dependencies(_libjpeg __libjpeg)
 set_target_properties(_libjpeg PROPERTIES
-    IMPORTED_LOCATION ${libjpeg_PREFIX}/lib/jpeg.lib
+    IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/jpeg.lib
 )
 
 set(JPEG_FOUND true PARENT_SCOPE)
-set(JPEG_INCLUDE_DIR "${libjpeg_PREFIX}/include" PARENT_SCOPE)
+set(JPEG_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include" PARENT_SCOPE)
 set(JPEG_LIBRARY _libjpeg PARENT_SCOPE)
 set(ExternConfig "${ExternConfig}
   add_library(_libjpeg STATIC IMPORTED)
   set_target_properties(_libjpeg PROPERTIES
-    IMPORTED_LOCATION ${libjpeg_PREFIX}/lib/jpeg.lib
+    IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/jpeg.lib
   )")
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,9 +134,6 @@ endif()
 #######################################################
 ## Setup required includes / link info
 
-# Project headers trump everything (including any potentially installed Pangolin)
-list(APPEND LIB_INC_DIR  "${PROJECT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}/include" )
-
 if(BUILD_PANGOLIN_GUI)
     if( ANDROID  )
         # Android specific display code
@@ -527,11 +524,14 @@ endif()
 #######################################################
 ## Add Libraries / Include Directories / Link directories
 
-include_directories( ${LIB_INC_DIR} )
-include_directories( ${USER_INC} )
-include_directories( ${INTERNAL_INC} )
+set(INSTALL_INCLUDE_DIR "include")
 
 add_library(${LIBRARY_NAME} ${SOURCES} ${HEADERS})
+target_include_directories(${LIBRARY_NAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                                                  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+                                                  $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
+                                                  ${USER_INC}
+                                           PRIVATE ${INTERNAL_INC})
 target_link_libraries(${LIBRARY_NAME} PUBLIC ${LINK_LIBS})
 
 ## Generate symbol export helper header on MSVC
@@ -545,7 +545,7 @@ IF(MSVC)
         STATIC_DEFINE ${LIBRARY_NAME_CAPS}_BUILT_AS_STATIC
     )
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${LIBRARY_NAME}/${LIBRARY_NAME}_export.h"
-      DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${LIBRARY_NAME}
+      DESTINATION ${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}/${LIBRARY_NAME}
     )
 ENDIF()
 
@@ -612,7 +612,7 @@ endif()
 set( CMAKECONFIG_INSTALL_DIR lib/cmake/${PROJECT_NAME} )
 file( RELATIVE_PATH REL_INCLUDE_DIR
     "${CMAKE_INSTALL_PREFIX}/${CMAKECONFIG_INSTALL_DIR}"
-    "${CMAKE_INSTALL_PREFIX}/include"
+    "${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}"
 )
 
 # Export library for easy inclusion from other cmake projects. APPEND allows
@@ -626,7 +626,7 @@ configure_file(${PROJECT_NAME}ConfigVersion.cmake.in
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake" @ONLY)
 
 # Build tree config
-set( EXPORT_LIB_INC_DIR ${LIB_INC_DIR} )
+set( EXPORT_LIB_INC_DIR "${PROJECT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}/include" )
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake @ONLY IMMEDIATE )
 
@@ -647,10 +647,10 @@ endif()
 ## Install headers / targets
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${LIBRARY_NAME}/config.h"
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${LIBRARY_NAME}
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}/${LIBRARY_NAME}
 )
 install(DIRECTORY ${INCDIR}
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}
 )
 install(TARGETS ${LIBRARY_NAME}
   EXPORT ${PROJECT_NAME}Targets


### PR DESCRIPTION
This PR adds support for modern target-based linking where the include directories are automatically propagated without further commands. The old fashioned way of linking (with `(target_)include_directories`) is still supported for users relying on it.