### PR TITLE
Add Render3D() method to GlTexture class to draw images in 3D space.

### DIFF
--- a/examples/SimpleDisplayImage/main.cpp
+++ b/examples/SimpleDisplayImage/main.cpp
@@ -63,6 +63,12 @@ int main(/*int argc, char* argv[]*/)
     glColor3f(1.0,1.0,1.0);
     imageTexture.RenderToViewport();
 
+    //display the image in 3D
+    d_cam.Activate(s_cam);
+    glColor3f(1.0,1.0,1.0);
+    GLfloat img_vertex[] = { -0.8,-0.6,3, 0.8,-0.6,3, 0.8,0.6,3, -0.8,0.6,3 };
+    imageTexture.Render3D(img_vertex);
+
     pangolin::FinishFrame();
   }
 

--- a/include/pangolin/gl/gl.h
+++ b/include/pangolin/gl/gl.h
@@ -105,6 +105,12 @@ public:
     void RenderToViewport(Viewport tex_vp, bool flipx=false, bool flipy=false) const;
     void RenderToViewportFlipY() const;
     void RenderToViewportFlipXFlipY() const;
+
+    //! Draw texture in 3D space given 4 vertex.
+    //! vertex_ptr pointer to vertex, it assumes size is 12 GLfloats (4x3) and vertex are in clockwise order
+    //! oneFaceOnly only draw texture in front face
+    //! backFaceTransparent if oneFaceOnly is enabled, back face is transparent or with solid color
+    void Render3D(const GLfloat* const vertex_ptr, bool oneFaceOnly=false, bool backFaceTransparent=false) const;
     
     GLint internal_format;
     GLuint tid;

--- a/include/pangolin/gl/gl.hpp
+++ b/include/pangolin/gl/gl.hpp
@@ -430,6 +430,46 @@ inline void GlTexture::RenderToViewportFlipXFlipY() const
     glDisable(GL_TEXTURE_2D);
 }
 
+inline void GlTexture::Render3D(const GLfloat* const vertex_ptr, bool oneFaceOnly, bool backFaceTransparent) const
+{
+
+    glVertexPointer(3, GL_FLOAT, 0, vertex_ptr);
+    glEnableClientState(GL_VERTEX_ARRAY);
+
+    GLfloat sq_tex[]  = { 0,0,  1,0,  1,1,  0,1  };
+    glTexCoordPointer(2, GL_FLOAT, 0, sq_tex);
+    glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+
+    if(oneFaceOnly)
+    {
+        // draw only front face
+        glCullFace(GL_FRONT);
+        glEnable(GL_CULL_FACE);
+    }
+
+    glEnable(GL_TEXTURE_2D);
+    Bind();
+
+    glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+    glDisable(GL_TEXTURE_2D);
+
+    if(oneFaceOnly)
+    {
+        if(!backFaceTransparent)
+        {
+            // draw back face with current color
+            glCullFace(GL_BACK);
+            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+        }
+
+        glDisable(GL_CULL_FACE);
+    }
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+}
+
 ////////////////////////////////////////////////////////////////////////////
 
 inline GlRenderBuffer::GlRenderBuffer()


### PR DESCRIPTION
I couldnt find a direct way to do this on the library and I think it can also be helpful for other developers.

Add Render3D() method to GlTexture class to allow drawing images in 3D space.
SimpleDisplayImage example also modified to show this feature.

Only tested on Ubuntu 14.04 but I think code is quite standard.