### PR TITLE
Remove unnecessary stdlib flag, allowing user to override if necessary.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install eigen glew ; fi
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      # install newer libstdc++ (from ubuntu-toolchain-r/test PPA), since otherwise clang fails with old libstdc++-4.8
+      - libstdc++-5-dev
+
 language: cpp
 
 compiler:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,6 @@ endif()
 
 if(NOT MSVC)
     set( CMAKE_CXX_FLAGS "-std=c++0x -Wall -Wextra ${CMAKE_CXX_FLAGS}" )
-    if(_CLANG_)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    endif()
 endif()
 
 if(ANDROID)


### PR DESCRIPTION
Fix #356.

I added `libstdc++-5-dev` from the `ubuntu-toolchain-r-test` PPA to make clang work on Linux (looks like the system default for trusty is too old, namely libstdc++-4.8).

The failure of GCC in Linux seems to be from master, but interestingly also fails in a libstdc++-4.8 header it seems.

Note that travis is already on clang-5.0, so no need to set it up manually (as you attempt in https://github.com/stevenlovegrove/Pangolin/commit/b98d8f70ea822de205dada9d2480d471a5fd9f37).

I could add to the README a note for Trusty users that want to use clang to install newer libstdc++ or pass flags to use libc++ is needed. Should I do that?

