### PR TITLE
GetCamCoordinates for Viewpoint to allow projection with fixed dimensions

### DIFF
--- a/include/pangolin/display/viewport.h
+++ b/include/pangolin/display/viewport.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <pangolin/gl/glinclude.h>
+#include <pangolin/display/opengl_render_state.h>
 
 namespace pangolin
 {
@@ -50,6 +51,8 @@ struct PANGOLIN_EXPORT Viewport
     Viewport Inset(int i) const;
     Viewport Inset(int horiz, int vert) const;
     Viewport Intersect(const Viewport& vp) const;
+
+    void GetCamCoordinates(const OpenGlRenderState& cam_state, double winx, double winy, double winzdepth, GLdouble& x, GLdouble& y, GLdouble& z) const;
     
     static void DisableScissor();
     

--- a/src/display/view.cpp
+++ b/src/display/view.cpp
@@ -389,13 +389,7 @@ void View::GetObjectCoordinates(const OpenGlRenderState& cam_state, double winx,
 
 void View::GetCamCoordinates(const OpenGlRenderState& cam_state, double winx, double winy, double winzdepth, GLdouble& x, GLdouble& y, GLdouble& z) const
 {
-    const GLint viewport[4] = {v.l,v.b,v.w,v.h};
-    const OpenGlMatrix proj = cam_state.GetProjectionMatrix();
-#ifndef HAVE_GLES
-    glUnProject(winx, winy, winzdepth, Identity4d, proj.m, viewport, &x, &y, &z);
-#else
-    glUnProject(winx, winy, winzdepth, Identity4f, proj.m, viewport, &x, &y, &z);
-#endif
+    v.GetCamCoordinates(cam_state, winx, winy, winzdepth, x, y, z);
 }
 
 View& View::SetFocus()

--- a/src/display/viewport.cpp
+++ b/src/display/viewport.cpp
@@ -27,6 +27,7 @@
 
 #include <pangolin/display/viewport.h>
 #include <algorithm>
+#include <pangolin/utils/simple_math.h>
 
 namespace pangolin {
 
@@ -96,6 +97,17 @@ Viewport Viewport::Intersect(const Viewport& vp) const
     GLint nb = std::max(b,vp.b);
     GLint nt = std::min(t(),vp.t());
     return Viewport(nl,nb, nr-nl, nt-nb);
+}
+
+void Viewport::GetCamCoordinates(const OpenGlRenderState& cam_state, double winx, double winy, double winzdepth, GLdouble& x, GLdouble& y, GLdouble& z) const
+{
+    const GLint viewport[4] = {l, b, w, h};
+    const OpenGlMatrix proj = cam_state.GetProjectionMatrix();
+#ifndef HAVE_GLES
+    glUnProject(winx, winy, winzdepth, Identity4d, proj.m, viewport, &x, &y, &z);
+#else
+    glUnProject(winx, winy, winzdepth, Identity4f, proj.m, viewport, &x, &y, &z);
+#endif
 }
 
 }


### PR DESCRIPTION
This PR creates a `GetCamCoordinates` method for the `Viewport` to allow projection with fixed viewport dimensions.

This simplifies the use like in https://github.com/stevenlovegrove/Pangolin/issues/375:

```C++
pangolin::Viewport offscreen_view(0,0,w,h);
offscreen_view.Activate();
offscreen_view.GetCamCoordinates(robot_cam, x, y, double(depth_gl(y,x)), points(y,x)[0], points(y,x)[1], points(y,x)[2]);
```