### PR TITLE
Fix invalid conversion error in display_wayland.cpp

### DIFF
--- a/src/display/device/display_wayland.cpp
+++ b/src/display/device/display_wayland.cpp
@@ -70,7 +70,7 @@ struct ButtonSurface {
         wl_subsurface_set_desync(subsurface);
         egl_context = eglCreateContext (egl_display, config, EGL_NO_CONTEXT, nullptr);
         egl_window = wl_egl_window_create(surface, width, height);
-        egl_surface = eglCreateWindowSurface(egl_display, config, egl_window, nullptr);
+        egl_surface = eglCreateWindowSurface(egl_display, config, (EGLNativeWindowType)egl_window, nullptr);
     }
 
     ~ButtonSurface() {
@@ -150,7 +150,7 @@ struct DecorationSurface {
         wl_subsurface_set_desync(subsurface);
         egl_context = eglCreateContext(egl_display, config, EGL_NO_CONTEXT, nullptr);
         egl_window = wl_egl_window_create(surface, 50, 50);
-        egl_surface = eglCreateWindowSurface(egl_display, config, egl_window, nullptr);
+        egl_surface = eglCreateWindowSurface(egl_display, config, (EGLNativeWindowType)egl_window, nullptr);
     }
 
     ~DecorationSurface() {
@@ -750,7 +750,7 @@ WaylandDisplay::WaylandDisplay(const int width, const int height, const std::str
 
     wl_display_roundtrip(wdisplay);
 
-    egl_display = eglGetDisplay(wdisplay);
+    egl_display = eglGetDisplay((EGLNativeDisplayType)wdisplay);
     if(!egl_display) {
         std::cerr << "Failed to open Wayland display" << std::endl;
     }


### PR DESCRIPTION
The following error happened:
```
Pangolin/src/display/device/display_wayland.cpp: In constructor ‘pangolin::wayland::ButtonSurface::ButtonSurface(wl_compositor*, wl_subcompositor*, wl_surface*, EGLDisplay, EGLConfig, int32_t, int32_t, uint, uint, pangolin::wayland::ButtonSurface::type, pangolin::Colour)’:
Pangolin/src/display/device/display_wayland.cpp:73:67: error: invalid conversion from ‘wl_egl_window*’ to ‘EGLNativeWindowType {aka long unsigned int}’ [-fpermissive]
         egl_surface = eglCreateWindowSurface(egl_display, config, egl_window, nullptr);
                                                                   ^
In file included from Pangolin/src/display/device/display_wayland.cpp:10:0:
/usr/include/EGL/egl.h:126:31: note:   initializing argument 3 of ‘void* eglCreateWindowSurface(EGLDisplay, EGLConfig, EGLNativeWindowType, const EGLint*)’
 EGLAPI EGLSurface EGLAPIENTRY eglCreateWindowSurface (EGLDisplay dpy, EGLConfig config, EGLNativeWindowType win, const EGLint *attrib_list);
                               ^
Pangolin/src/display/device/display_wayland.cpp: In constructor ‘pangolin::wayland::DecorationSurface::DecorationSurface(wl_compositor*, wl_subcompositor*, wl_surface*, EGLDisplay, EGLConfig, uint, uint, wl_shell_surface_resize, pangolin::Colour)’:
Pangolin/src/display/device/display_wayland.cpp:153:67: error: invalid conversion from ‘wl_egl_window*’ to ‘EGLNativeWindowType {aka long unsigned int}’ [-fpermissive]
         egl_surface = eglCreateWindowSurface(egl_display, config, egl_window, nullptr);
                                                                   ^
In file included from Pangolin/src/display/device/display_wayland.cpp:10:0:
/usr/include/EGL/egl.h:126:31: note:   initializing argument 3 of ‘void* eglCreateWindowSurface(EGLDisplay, EGLConfig, EGLNativeWindowType, const EGLint*)’
 EGLAPI EGLSurface EGLAPIENTRY eglCreateWindowSurface (EGLDisplay dpy, EGLConfig config, EGLNativeWindowType win, const EGLint *attrib_list);
                               ^
Pangolin/src/display/device/display_wayland.cpp: In constructor ‘pangolin::wayland::WaylandDisplay::WaylandDisplay(int, int, std::__cxx11::string)’:
Pangolin/src/display/device/display_wayland.cpp:753:41: error: cannot convert ‘wl_display*’ to ‘EGLNativeDisplayType {aka _XDisplay*}’ for argument ‘1’ to ‘void* eglGetDisplay(EGLNativeDisplayType)’
     egl_display = eglGetDisplay(wdisplay);
                                         ^
In file included from /usr/include/wayland-client.h:39:0,
                 from Pangolin/src/display/device/display_wayland.cpp:8:
/usr/include/wayland-client-core.h:110:8: note: class type ‘wl_display’ is incomplete
 struct wl_display;
        ^
src/CMakeFiles/pangolin.dir/build.make:1574: recipe for target 'src/CMakeFiles/pangolin.dir/display/device/display_wayland.cpp.o' failed
make[2]: *** 
```
This error is fixed in this PR.