### PR TITLE
Fix Windows black screen

### DIFF
--- a/src/display/device/display_win.cpp
+++ b/src/display/device/display_win.cpp
@@ -222,8 +222,8 @@ WinWindow::WinWindow(
     }
     RegisterThisClass(hCurrentInst);
 
-    PangolinGl::windowed_size[0] = 0;
-    PangolinGl::windowed_size[1] = 0;
+    PangolinGl::windowed_size[0] = width;
+    PangolinGl::windowed_size[1] = height;
 
     HWND thishwnd = CreateWindow(
         className, window_title.c_str(),


### PR DESCRIPTION
Initialize the default Windows windows to width/height instead
of 0.

Fixes: https://github.com/stevenlovegrove/Pangolin/issues/367

TEST: Runs the windows samples without having to resize