### PR TITLE
Headless windows via EGL

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,7 @@
 # All examples depend on Pangolin GUI
 if(BUILD_PANGOLIN_GUI)
     add_subdirectory(HelloPangolin)
+    add_subdirectory(HelloPangolinOffscreen)
     add_subdirectory(HelloPangolinThreads)
     add_subdirectory(SimpleMultiDisplay)
     add_subdirectory(SimpleDisplayImage)

--- a/examples/HelloPangolinOffscreen/CMakeLists.txt
+++ b/examples/HelloPangolinOffscreen/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Find Pangolin (https://github.com/stevenlovegrove/Pangolin)
+find_package(Pangolin 0.5 REQUIRED)
+include_directories(${Pangolin_INCLUDE_DIRS})
+
+add_executable(HelloPangolinOffscreen main.cpp)
+target_link_libraries(HelloPangolinOffscreen ${Pangolin_LIBRARIES})

--- a/examples/HelloPangolinOffscreen/main.cpp
+++ b/examples/HelloPangolinOffscreen/main.cpp
@@ -1,0 +1,34 @@
+#include <pangolin/pangolin.h>
+
+int main( int /*argc*/, char** /*argv*/ )
+{
+    pangolin::CreateWindowAndBind("Main",640,480);
+    glEnable(GL_DEPTH_TEST);
+
+    // Define Projection and initial ModelView matrix
+    pangolin::OpenGlRenderState s_cam(
+        pangolin::ProjectionMatrix(640,480,420,420,320,240,0.2,100),
+        pangolin::ModelViewLookAt(-2,2,-2, 0,0,0, pangolin::AxisY)
+    );
+
+    // Create Interactive View in window
+    pangolin::Handler3D handler(s_cam);
+    pangolin::View& d_cam = pangolin::CreateDisplay()
+            .SetBounds(0.0, 1.0, 0.0, 1.0, -640.0f/480.0f)
+            .SetHandler(&handler);
+
+    while( !pangolin::ShouldQuit() )
+    {
+        // Clear screen and activate view to render into
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        d_cam.Activate(s_cam);
+
+        // Render OpenGL Cube
+        pangolin::glDrawColouredCube();
+
+        // Swap frames and Process Events
+        pangolin::FinishFrame();
+    }
+    
+    return 0;
+}

--- a/examples/HelloPangolinOffscreen/main.cpp
+++ b/examples/HelloPangolinOffscreen/main.cpp
@@ -2,7 +2,7 @@
 
 int main( int /*argc*/, char** /*argv*/ )
 {
-    pangolin::CreateWindowAndBind("Main",640,480);
+    pangolin::CreateWindowAndBind("Main",640,480,pangolin::Params(),"headless");
     glEnable(GL_DEPTH_TEST);
 
     // Define Projection and initial ModelView matrix

--- a/examples/HelloPangolinOffscreen/main.cpp
+++ b/examples/HelloPangolinOffscreen/main.cpp
@@ -2,7 +2,7 @@
 
 int main( int /*argc*/, char** /*argv*/ )
 {
-    pangolin::CreateWindowAndBind("Main",640,480,pangolin::Params(),"headless");
+    pangolin::CreateWindowAndBind("Main",640,480,pangolin::Params({{"scheme", "headless"}}));
     glEnable(GL_DEPTH_TEST);
 
     // Define Projection and initial ModelView matrix

--- a/examples/HelloPangolinOffscreen/main.cpp
+++ b/examples/HelloPangolinOffscreen/main.cpp
@@ -17,6 +17,8 @@ int main( int /*argc*/, char** /*argv*/ )
             .SetBounds(0.0, 1.0, 0.0, 1.0, -640.0f/480.0f)
             .SetHandler(&handler);
 
+    pangolin::SaveWindowOnRender("window");
+
     while( !pangolin::ShouldQuit() )
     {
         // Clear screen and activate view to render into

--- a/examples/HelloPangolinOffscreen/main.cpp
+++ b/examples/HelloPangolinOffscreen/main.cpp
@@ -19,18 +19,17 @@ int main( int /*argc*/, char** /*argv*/ )
 
     pangolin::SaveWindowOnRender("window");
 
-    while( !pangolin::ShouldQuit() )
-    {
-        // Clear screen and activate view to render into
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        d_cam.Activate(s_cam);
+    // Clear screen and activate view to render into
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    d_cam.Activate(s_cam);
 
-        // Render OpenGL Cube
-        pangolin::glDrawColouredCube();
+    // Render OpenGL Cube
+    pangolin::glDrawColouredCube();
 
-        // Swap frames and Process Events
-        pangolin::FinishFrame();
-    }
+    // Swap frames and Process Events
+    pangolin::FinishFrame();
+
+    pangolin::QuitAll();
     
     return 0;
 }

--- a/include/pangolin/display/display.h
+++ b/include/pangolin/display/display.h
@@ -69,7 +69,7 @@ namespace pangolin
   /// Initialise OpenGL window (determined by platform) and bind context.
   /// This method will choose an available windowing system if one is present.
   PANGOLIN_EXPORT
-  WindowInterface& CreateWindowAndBind(std::string window_title, int w = 640, int h = 480, const Params& params = Params());
+  WindowInterface& CreateWindowAndBind(std::string window_title, int w = 640, int h = 480, const Params& params = Params(), const std::string& scheme = std::string());
 
   /// Return pointer to current Pangolin Window context, or nullptr if none bound.
   PANGOLIN_EXPORT

--- a/include/pangolin/display/display.h
+++ b/include/pangolin/display/display.h
@@ -69,7 +69,7 @@ namespace pangolin
   /// Initialise OpenGL window (determined by platform) and bind context.
   /// This method will choose an available windowing system if one is present.
   PANGOLIN_EXPORT
-  WindowInterface& CreateWindowAndBind(std::string window_title, int w = 640, int h = 480, const Params& params = Params(), const std::string& scheme = std::string());
+  WindowInterface& CreateWindowAndBind(std::string window_title, int w = 640, int h = 480, const Params& params = Params());
 
   /// Return pointer to current Pangolin Window context, or nullptr if none bound.
   PANGOLIN_EXPORT

--- a/include/pangolin/factory/factory_registry.h
+++ b/include/pangolin/factory/factory_registry.h
@@ -82,7 +82,7 @@ public:
     {
         // Iterate over all registered factories in order of precedence.
         for(auto& item : factories) {
-            if( item.scheme == uri.scheme) {
+            if( item.scheme == uri.Get<std::string>("scheme")) {
                 std::unique_ptr<T> video = item.factory->Open(uri);
                 if(video) {
                     return video;

--- a/include/pangolin/gl/glinclude.h
+++ b/include/pangolin/gl/glinclude.h
@@ -39,8 +39,8 @@ inline void _CheckGlDieOnError( const char *sFile, const int nLine )
 {
     GLenum glError = glGetError();
     if( glError != GL_NO_ERROR ) {
-        pango_print_error( "OpenGL Error: %s (%d)\n", glErrorString(glError), glError );
-		pango_print_error("In: %s, line %d\n", sFile, nLine);
+        pango_print_error( "OpenGL Error: %s (%x)\n", glErrorString(glError), glError );
+        pango_print_error("In: %s, line %d\n", sFile, nLine);
     }
 }
 }

--- a/include/pangolin/utils/params.h
+++ b/include/pangolin/utils/params.h
@@ -59,7 +59,7 @@ public:
     }
 
     template<typename T>
-    T Get(const std::string& key, T default_val) const
+    T Get(const std::string& key, const T default_val = T()) const
     {
         // Return last value passed to the key.
         for(ParamMap::const_reverse_iterator it = params.rbegin(); it!=params.rend(); ++it) {

--- a/include/pangolin/utils/uri.h
+++ b/include/pangolin/utils/uri.h
@@ -37,7 +37,6 @@ namespace pangolin
 class PANGOLIN_EXPORT Uri : public Params
 {
 public:
-    std::string scheme;
     std::string url;
     std::string full_uri;
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -178,6 +178,13 @@ if(BUILD_PANGOLIN_GUI)
         list(APPEND HEADERS ${INCDIR}/gl2engine.h )
         list(APPEND SOURCES gl2engine.cpp)
     endif()
+
+    # headless
+    find_package(PkgConfig)
+    pkg_check_modules(egl REQUIRED egl)
+    list(APPEND WINDOW_FACTORY_REG RegisterNoneWindowFactory)
+    list(APPEND SOURCES display/device/display_headless.cpp)
+    list(APPEND LINK_LIBS ${egl_LIBRARIES} )
 endif()
 
 #######################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,12 +179,13 @@ if(BUILD_PANGOLIN_GUI)
         list(APPEND SOURCES gl2engine.cpp)
     endif()
 
-    # headless
-    find_package(PkgConfig)
-    pkg_check_modules(egl REQUIRED egl)
-    list(APPEND WINDOW_FACTORY_REG RegisterNoneWindowFactory)
-    list(APPEND SOURCES display/device/display_headless.cpp)
-    list(APPEND LINK_LIBS ${egl_LIBRARIES} )
+    # headless offscreen rendering via EGL
+    find_package(OpenGL QUIET COMPONENTS EGL)
+    if(OpenGL_EGL_FOUND)
+        list(APPEND WINDOW_FACTORY_REG RegisterNoneWindowFactory)
+        list(APPEND SOURCES display/device/display_headless.cpp)
+        list(APPEND LINK_LIBS ${OPENGL_egl_LIBRARY} )
+    endif()
 endif()
 
 #######################################################
@@ -233,7 +234,7 @@ else()
                 list(APPEND SOURCES display/device/display_x11.cpp )
                 list(APPEND LINK_LIBS ${X11_LIBRARIES} )
             endif()
-            
+
             if(NOT wayland-client_FOUND AND NOT X11_FOUND)
                 message(FATAL_ERROR "At least one of X11 or Wayland must be found for Pangolin GUI support.")
             endif()

--- a/src/display/device/display_headless.cpp
+++ b/src/display/device/display_headless.cpp
@@ -1,0 +1,164 @@
+#include <pangolin/display/display_internal.h>
+#include <pangolin/factory/factory_registry.h>
+#include <EGL/egl.h>
+
+namespace pangolin {
+
+extern __thread PangolinGl* context;
+
+namespace headless {
+
+class EGLDisplayHL {
+public:
+    EGLDisplayHL(const int width, const int height);
+
+    ~EGLDisplayHL();
+
+    void swap();
+
+    void makeCurrent();
+
+    void removeCurrent();
+
+private:
+    EGLSurface egl_surface;
+    EGLContext egl_context;
+    EGLDisplay egl_display;
+
+    static constexpr EGLint attribs[] = {
+        EGL_SURFACE_TYPE    , EGL_PBUFFER_BIT,
+        EGL_RENDERABLE_TYPE , EGL_OPENGL_BIT,
+        EGL_RED_SIZE        , 8,
+        EGL_GREEN_SIZE      , 8,
+        EGL_BLUE_SIZE       , 8,
+        EGL_ALPHA_SIZE      , 8,
+        EGL_DEPTH_SIZE      , 24,
+        EGL_STENCIL_SIZE    , 8,
+        EGL_NONE
+    };
+};
+
+constexpr EGLint EGLDisplayHL::attribs[];
+
+struct HeadlessWindow : public PangolinGl {
+    HeadlessWindow(const int width, const int height);
+
+    ~HeadlessWindow() override;
+
+    void ToggleFullscreen() override;
+
+    void Move(const int x, const int y) override;
+
+    void Resize(const unsigned int w, const unsigned int h) override;
+
+    void MakeCurrent() override;
+
+    void RemoveCurrent() override;
+
+    void SwapBuffers() override;
+
+    void ProcessEvents() override;
+
+    EGLDisplayHL display;
+};
+
+EGLDisplayHL::EGLDisplayHL(const int width, const int height) {
+    egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    if(!egl_display) {
+        std::cerr << "Failed to open EGL display" << std::endl;
+    }
+
+    EGLint major, minor;
+    if(eglInitialize(egl_display, &major, &minor)==EGL_FALSE) {
+        std::cerr << "EGL init failed" << std::endl;
+    }
+
+    if(eglBindAPI(EGL_OPENGL_API)==EGL_FALSE) {
+        std::cerr << "EGL bind failed" << std::endl;
+    }
+
+    EGLint count;
+    eglGetConfigs(egl_display, nullptr, 0, &count);
+
+    std::vector<EGLConfig> egl_configs(count);
+
+    EGLint numConfigs;
+    eglChooseConfig(egl_display, attribs, egl_configs.data(), count, &numConfigs);
+
+    egl_context = eglCreateContext(egl_display, egl_configs[0], EGL_NO_CONTEXT, nullptr);
+
+    const EGLint pbufferAttribs[] = {
+        EGL_WIDTH, width,
+        EGL_HEIGHT, height,
+        EGL_NONE,
+    };
+    egl_surface = eglCreatePbufferSurface(egl_display, egl_configs[0],  pbufferAttribs);
+    if (egl_surface == EGL_NO_SURFACE) {
+        std::cerr << "Cannot create EGL surface" << std::endl;
+    }
+}
+
+EGLDisplayHL::~EGLDisplayHL() {
+    if(egl_context) eglDestroyContext(egl_display, egl_context);
+    if(egl_surface) eglDestroySurface(egl_display, egl_surface);
+    if(egl_display) eglTerminate(egl_display);
+}
+
+void EGLDisplayHL::swap() {
+    eglSwapBuffers(egl_display, egl_surface);
+}
+
+void EGLDisplayHL::makeCurrent() {
+    eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
+}
+
+void EGLDisplayHL::removeCurrent() {
+    eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+}
+
+HeadlessWindow::HeadlessWindow(const int w, const int h) : display(w, h) {
+    windowed_size[0] = w;
+    windowed_size[1] = h;
+}
+
+HeadlessWindow::~HeadlessWindow() { }
+
+void HeadlessWindow::MakeCurrent() {
+    display.makeCurrent();
+    context = this;
+}
+
+void HeadlessWindow::RemoveCurrent() {
+    display.removeCurrent();
+}
+
+void HeadlessWindow::ToggleFullscreen() { }
+
+void HeadlessWindow::Move(const int /*x*/, const int /*y*/) { }
+
+void HeadlessWindow::Resize(const unsigned int /*w*/, const unsigned int /*h*/) { }
+
+void HeadlessWindow::ProcessEvents() { }
+
+void HeadlessWindow::SwapBuffers() {
+    display.swap();
+    MakeCurrent();
+}
+
+} // namespace headless
+
+PANGOLIN_REGISTER_FACTORY(NoneWindow) {
+struct HeadlessWindowFactory : public FactoryInterface<WindowInterface> {
+    std::unique_ptr<WindowInterface> Open(const Uri& uri) override {
+        return std::unique_ptr<WindowInterface>(new headless::HeadlessWindow(uri.Get<int>("w", 640), uri.Get<int>("h", 480)));
+    }
+
+    virtual ~HeadlessWindowFactory() { }
+};
+
+auto factory = std::make_shared<HeadlessWindowFactory>();
+FactoryRegistry<WindowInterface>::I().RegisterFactory(factory, 1, "headless");
+}
+
+} // namespace pangolin
+

--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -131,20 +131,20 @@ WindowInterface& CreateWindowAndBind(std::string window_title, int w, int h, con
     }
 
     // Override with anything the program specified
-    if(!scheme.empty()) { win_uri.scheme = scheme; }
+    if(!scheme.empty()) { win_uri.Set("scheme", scheme); }
     win_uri.Set("w", w);
     win_uri.Set("h", h);
     win_uri.Set("window_title", window_title);
     win_uri.params.insert(std::end(win_uri.params), std::begin(params.params), std::end(params.params));
 
     // Fall back to default scheme if non specified.
-    if(win_uri.scheme.empty()) {
+    if(win_uri.Get<std::string>("scheme").empty()) {
 #if defined(_LINUX_)
-      win_uri.scheme = "linux";
+      win_uri.Get<std::string>("scheme") = "linux";
 #elif defined(_WIN_)
-      win_uri.scheme = "winapi";
+      win_uri.Get<std::string>("scheme") = "winapi";
 #elif defined(_OSX_)
-      win_uri.scheme = "cocoa";
+      win_uri.Get<std::string>("scheme") = "cocoa";
 #else
 #     error "No default window api for this platform."
 #endif
@@ -154,7 +154,7 @@ WindowInterface& CreateWindowAndBind(std::string window_title, int w, int h, con
 
     // We're expecting not only a WindowInterface, but a PangolinGl.
     if(!window || !dynamic_cast<PangolinGl*>(window.get())) {
-        throw WindowExceptionNoKnownHandler(win_uri.scheme);
+        throw WindowExceptionNoKnownHandler(win_uri.Get<std::string>("scheme"));
     }
 
     std::shared_ptr<PangolinGl> context(dynamic_cast<PangolinGl*>(window.release()));

--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -114,7 +114,7 @@ PangolinGl *FindContext(const std::string& name)
     return context;
 }
 
-WindowInterface& CreateWindowAndBind(std::string window_title, int w, int h, const Params& params, const std::string& scheme)
+WindowInterface& CreateWindowAndBind(std::string window_title, int w, int h, const Params& params)
 {
     std::unique_lock<std::recursive_mutex> l(contexts_mutex);
 
@@ -131,7 +131,7 @@ WindowInterface& CreateWindowAndBind(std::string window_title, int w, int h, con
     }
 
     // Override with anything the program specified
-    if(!scheme.empty()) { win_uri.Set("scheme", scheme); }
+    if(!params.Get<std::string>("scheme").empty()) { win_uri.Set("scheme", params.Get<std::string>("scheme")); }
     win_uri.Set("w", w);
     win_uri.Set("h", h);
     win_uri.Set("window_title", window_title);

--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -114,7 +114,7 @@ PangolinGl *FindContext(const std::string& name)
     return context;
 }
 
-WindowInterface& CreateWindowAndBind(std::string window_title, int w, int h, const Params& params)
+WindowInterface& CreateWindowAndBind(std::string window_title, int w, int h, const Params& params, const std::string& scheme)
 {
     std::unique_lock<std::recursive_mutex> l(contexts_mutex);
 
@@ -131,6 +131,7 @@ WindowInterface& CreateWindowAndBind(std::string window_title, int w, int h, con
     }
 
     // Override with anything the program specified
+    if(!scheme.empty()) { win_uri.scheme = scheme; }
     win_uri.Set("w", w);
     win_uri.Set("h", h);
     win_uri.Set("window_title", window_title);

--- a/src/utils/uri.cpp
+++ b/src/utils/uri.cpp
@@ -44,10 +44,10 @@ Uri ParseUri(const std::string &str_uri)
     const size_t ns = str_uri.find(':', npos);
     if( ns != std::string::npos )
     {
-        uri.scheme = str_uri.substr(0,ns);
+        uri.Set("scheme", str_uri.substr(0,ns));
         npos = ns+1;
     }else{
-        uri.scheme = "file";
+        uri.Set("scheme", "file");
         uri.url = str_uri;
         return uri;
     }
@@ -88,7 +88,7 @@ Uri ParseUri(const std::string &str_uri)
 
 std::ostream& operator<< (std::ostream &out, Uri &uri)
 {
-    out << "scheme: " << uri.scheme << std::endl;
+    out << "scheme: " << uri.Get<std::string>("scheme") << std::endl;
     out << "url:    " << uri.url << std::endl;
     out << "params:" << std::endl;
 

--- a/src/video/drivers/ffmpeg.cpp
+++ b/src/video/drivers/ffmpeg.cpp
@@ -888,9 +888,9 @@ PANGOLIN_REGISTER_FACTORY(FfmpegVideo)
                 ".webm", ".wmv", ".yuv", ".h264", ".h265"
             }};
 
-            if(!uri.scheme.compare("ffmpeg") || !uri.scheme.compare("file") || !uri.scheme.compare("files") )
+            if(!uri.Get<std::string>("scheme").compare("ffmpeg") || !uri.Get<std::string>("scheme").compare("file") || !uri.Get<std::string>("scheme").compare("files") )
             {
-                if(!uri.scheme.compare("file") || !uri.scheme.compare("files")) {
+                if(!uri.Get<std::string>("scheme").compare("file") || !uri.Get<std::string>("scheme").compare("files")) {
                     const std::string ext = FileLowercaseExtention(uri.url);
                     if(std::find(ffmpeg_ext.begin(), ffmpeg_ext.end(), ext) == ffmpeg_ext.end()) {
                         // Don't try to load unknown files without the ffmpeg:// scheme.
@@ -901,13 +901,13 @@ PANGOLIN_REGISTER_FACTORY(FfmpegVideo)
                 ToUpper(outfmt);
                 const int video_stream = uri.Get<int>("stream",-1);
                 return std::unique_ptr<VideoInterface>( new FfmpegVideo(uri.url.c_str(), outfmt, "", false, video_stream) );
-            }else if( !uri.scheme.compare("v4lmjpeg")) {
+            }else if( !uri.Get<std::string>("scheme").compare("v4lmjpeg")) {
                 const int video_stream = uri.Get<int>("stream",-1);
                 const ImageDim size = uri.Get<ImageDim>("size",ImageDim(0,0));
                 return std::unique_ptr<VideoInterface>( new FfmpegVideo(uri.url.c_str(),"RGB24", "video4linux", false, video_stream, size) );
-            } else if( !uri.scheme.compare("mjpeg")) {
+            } else if( !uri.Get<std::string>("scheme").compare("mjpeg")) {
                 return std::unique_ptr<VideoInterface>( new FfmpegVideo(uri.url.c_str(),"RGB24", "MJPEG" ) );
-            }else if( !uri.scheme.compare("convert") ) {
+            }else if( !uri.Get<std::string>("scheme").compare("convert") ) {
                 std::string outfmt = uri.Get<std::string>("fmt","RGB24");
                 ToUpper(outfmt);
                 std::unique_ptr<VideoInterface> subvid = pangolin::OpenVideo(uri.url);

--- a/src/video/drivers/json.cpp
+++ b/src/video/drivers/json.cpp
@@ -40,7 +40,7 @@ PANGOLIN_REGISTER_FACTORY(JsonVideo)
 {
     struct JsonVideoFactory final : public FactoryInterface<VideoInterface> {
         std::unique_ptr<VideoInterface> Open(const Uri& uri) override {
-            if(uri.scheme == "json" || (uri.scheme == "file" && FileLowercaseExtention(uri.url) == ".json")) {
+            if(uri.Get<std::string>("scheme") == "json" || (uri.Get<std::string>("scheme") == "file" && FileLowercaseExtention(uri.url) == ".json")) {
                 const std::string json_filename = PathExpand(uri.url);
                 std::ifstream f( json_filename );
 

--- a/src/video/drivers/mirror.cpp
+++ b/src/video/drivers/mirror.cpp
@@ -557,11 +557,11 @@ PANGOLIN_REGISTER_FACTORY(MirrorVideo)
             std::unique_ptr<VideoInterface> subvid = pangolin::OpenVideo(uri.url);
 
             MirrorOptions default_opt = MirrorOptionsNone;
-            if(uri.scheme == "flip") default_opt = MirrorOptionsFlipY;
-            if(uri.scheme == "rotate") default_opt = MirrorOptionsFlipXY;
-            if(uri.scheme == "transpose") default_opt = MirrorOptionsTranspose;
-            if(uri.scheme == "rotateCW") default_opt = MirrorOptionsRotateCW;
-            if(uri.scheme == "rotateCCW") default_opt = MirrorOptionsRotateCCW;
+            if(uri.Get<std::string>("scheme") == "flip") default_opt = MirrorOptionsFlipY;
+            if(uri.Get<std::string>("scheme") == "rotate") default_opt = MirrorOptionsFlipXY;
+            if(uri.Get<std::string>("scheme") == "transpose") default_opt = MirrorOptionsTranspose;
+            if(uri.Get<std::string>("scheme") == "rotateCW") default_opt = MirrorOptionsRotateCW;
+            if(uri.Get<std::string>("scheme") == "rotateCCW") default_opt = MirrorOptionsRotateCCW;
 
             std::vector<MirrorOptions> flips;
 

--- a/src/video/drivers/pango.cpp
+++ b/src/video/drivers/pango.cpp
@@ -228,7 +228,7 @@ PANGOLIN_REGISTER_FACTORY(PangoVideo)
         std::unique_ptr<VideoInterface> Open(const Uri& uri) override {
             const std::string path = PathExpand(uri.url);
 
-            if( !uri.scheme.compare("pango") || FileType(uri.url) == ImageFileTypePango ) {
+            if( !uri.Get<std::string>("scheme").compare("pango") || FileType(uri.url) == ImageFileTypePango ) {
                 return std::unique_ptr<VideoInterface>(new PangoVideo(path.c_str(), PlaybackSession::ChooseFromParams(uri)));
             }
             return std::unique_ptr<VideoInterface>();

--- a/src/video/drivers/pvn.cpp
+++ b/src/video/drivers/pvn.cpp
@@ -120,7 +120,7 @@ PANGOLIN_REGISTER_FACTORY(PvnVideo)
         std::unique_ptr<VideoInterface> Open(const Uri& uri) override {
             const std::string path = PathExpand(uri.url);
 
-            if( !uri.scheme.compare("pvn") || FileType(uri.url) == ImageFileTypePvn ) {
+            if( !uri.Get<std::string>("scheme").compare("pvn") || FileType(uri.url) == ImageFileTypePvn ) {
                 const bool realtime = uri.Contains("realtime");
                 return std::unique_ptr<VideoInterface>(new PvnVideo(path.c_str(), realtime));
             }

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<VideoInterface> OpenVideo(const Uri& uri)
             FactoryRegistry<VideoInterface>::I().Open(uri);
 
     if(!video) {
-        throw VideoExceptionNoKnownHandler(uri.scheme);
+        throw VideoExceptionNoKnownHandler(uri.Get<std::string>("scheme"));
     }
 
     return video;
@@ -71,7 +71,7 @@ std::unique_ptr<VideoOutputInterface> OpenVideoOutput(const Uri& uri)
             FactoryRegistry<VideoOutputInterface>::I().Open(uri);
 
     if(!video) {
-        throw VideoException("No known video handler for URI '" + uri.scheme + "'");
+        throw VideoException("No known video handler for URI '" + uri.Get<std::string>("scheme") + "'");
     }
 
     return video;

--- a/src/video/video_input.cpp
+++ b/src/video/video_input.cpp
@@ -52,9 +52,9 @@ void VideoInput::Open(
     uri_input = ParseUri(input_uri);
     uri_output = ParseUri(output_uri);
 
-    if (uri_output.scheme == "file") {
+    if (uri_output.Get<std::string>("scheme") == "file") {
         // Default to pango output
-        uri_output.scheme = "pango";
+        uri_output.Get<std::string>("scheme") = "pango";
     }
 
     // Start off playing from video_src


### PR DESCRIPTION
This PR implements offscreen rendering via EGL's pixel buffer surface (fixes issue https://github.com/stevenlovegrove/Pangolin/issues/374). The new `HeadlessWindow` is defining the scheme `headless` that needs to be set either via an environment variable, e.g.: `export PANGOLIN_WINDOW_URI=headless:`, or via a new scheme parameter for `CreateWindowAndBind`, as shown in the `HelloPangolinOffscreen` example.

Since this feature is using EGL, it currently suffers from the same nvidia driver issues discussed in https://github.com/stevenlovegrove/Pangolin/pull/389. That is, on some combinations of Linux distribution and nvidia driver, the screen is black / rendered image is empty. E.g. Ubuntu 16.04 gives a blank screen/image and the newer Ubuntu 18.04 correctly renders via EGL.
However, this PR does not effect the other window and context creation routines.