### PR TITLE
fix garbled framerate

### DIFF
--- a/src/video/drivers/ffmpeg.cpp
+++ b/src/video/drivers/ffmpeg.cpp
@@ -529,8 +529,6 @@ static AVStream* CreateStream(AVFormatContext *oc, CodecID codec_id, uint64_t fr
         stream->codec->time_base.den = frame_rate;
         stream->codec->gop_size      = 12;
         stream->codec->pix_fmt       = EncoderFormat;
-        stream->time_base.num = 1;
-        stream->time_base.den = frame_rate;
         break;
     default:
         break;
@@ -584,9 +582,23 @@ void FfmpegVideoOutputStream::WriteAvPacket(AVPacket* pkt)
 {
     if (pkt->size) {
         pkt->stream_index = stream->index;
+        int64_t pts = pkt->pts;
+        /* convert unit from CODEC's timestamp to stream's one */
+#define C2S(field)                                              \
+        do {                                                    \
+          if (pkt->field != (int64_t) AV_NOPTS_VALUE)           \
+            pkt->field = av_rescale_q(pkt->field,               \
+                                      stream->codec->time_base, \
+                                      stream->time_base);       \
+        } while (0)
+
+        C2S(pts);
+        C2S(dts);
+        C2S(duration);
+#undef C2S
         int ret = av_interleaved_write_frame(recorder.oc, pkt);
         if (ret < 0) throw VideoException("Error writing video frame");
-        if(pkt->pts != (int64_t)AV_NOPTS_VALUE) last_pts = pkt->pts;
+        if(pkt->pts != (int64_t)AV_NOPTS_VALUE) last_pts = pts;
     }
 }
 


### PR DESCRIPTION
When I use `View::RecordOnRender()` to generate an video (see below), the generated video has incorrect (extremely large) FPS.
This is because the current Pangolin assumes that FFmpeg honors stream's timebase (`AVStream::time_base`) which is only a hint and may be overwritten (as described in [the libavformat's document](https://www.ffmpeg.org/doxygen/trunk/structAVStream.html#a9db755451f14e2bf590d4b85d82b32e6)).

This PR fixes the problem by converting timestamps (pts, dts, ...) from CODEC-based one to stream-based one as described in [the libavcodec's document](https://www.ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga37352ed2c63493c38219d935e71db6c1).

```
/* code to reproduce (based on example/HelloPangolin/main.cc) */
...
pangolin::View& d_cam = pangolin::CreateDisplay().SetBounds(...).SetHandler(...);
d_cam.RecordOnRender("ffmpeg:[fps=27]//foo.mp4");

for (int i=0; i<314; i++) {
    ...
    pangolin::FinishFrame();
}

/* the generated video should be 27 FPS, but I got 11776(!) FPS */
```