### PR TITLE
Fixing an issue with windows top bar

### DIFF
--- a/src/display/device/display_win.cpp
+++ b/src/display/device/display_win.cpp
@@ -222,9 +222,6 @@ WinWindow::WinWindow(
     }
     RegisterThisClass(hCurrentInst);
 
-    PangolinGl::windowed_size[0] = width;
-    PangolinGl::windowed_size[1] = height;
-
     HWND thishwnd = CreateWindow(
         className, window_title.c_str(),
         WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN | WS_CLIPSIBLINGS,
@@ -238,6 +235,13 @@ WinWindow::WinWindow(
     if( thishwnd != hWnd ) {
         throw std::runtime_error("Pangolin Window Creation Failed.");
     }
+
+    // Gets the size of the window, excluding the top bar
+    RECT cRect;
+    GetClientRect(thishwnd, &cRect);
+
+    PangolinGl::windowed_size[0] = cRect.right;
+    PangolinGl::windowed_size[1] = cRect.bottom;
 
     // Display Window
     ShowWindow(hWnd, SW_SHOW);


### PR DESCRIPTION
On Windows this fixes an issue in which the UI elements are offset by the size of the top Windows bar. Getting the actual client dimensions seems to fix it. See images for comparison before and after.

![before](https://user-images.githubusercontent.com/24234483/50662192-df300f00-0fa5-11e9-9649-1dfb657cfa9a.gif)

![after](https://user-images.githubusercontent.com/24234483/50662206-e5be8680-0fa5-11e9-84ee-741704054bf3.gif)
