### PR TITLE
Fix Pangolin virtual destructor error

### DIFF
--- a/include/pangolin/scene/interactive.h
+++ b/include/pangolin/scene/interactive.h
@@ -37,6 +37,8 @@ struct Interactive
 {
     static __thread GLuint current_id;
 
+    virtual ~Interactive() {}
+
     virtual bool Mouse(
         int button,
         const GLprecision win[3], const GLprecision obj[3], const GLprecision normal[3],


### PR DESCRIPTION
This fixes a runtime crash when running with [UndefinedBehaviorSanitizer](http://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) enabled because the Interactive interface was missing a virtual destructor.