### PR TITLE
Catch exceptions by const reference

### DIFF
--- a/examples/SimpleRecord/main.cpp
+++ b/examples/SimpleRecord/main.cpp
@@ -85,7 +85,7 @@ int main( int argc, char* argv[] )
                 std::cout << "Trying: " << input_uris[i] << std::endl;
                 RecordSample(input_uris[i], record_uri);
                 return 0;
-            }catch(pangolin::VideoException) {}
+            }catch(const pangolin::VideoException&) {}
         }
     }
 

--- a/examples/SimpleVideo/main.cpp
+++ b/examples/SimpleVideo/main.cpp
@@ -103,7 +103,7 @@ int main( int argc, char* argv[] )
                 std::cout << "Trying: " << uris[i] << std::endl;
                 VideoSample(uris[i]);
                 return 0;
-            }catch(pangolin::VideoException) { }
+            }catch(const pangolin::VideoException&) { }
         }
     }
 

--- a/include/pangolin/python/pyvar.h
+++ b/include/pangolin/python/pyvar.h
@@ -64,7 +64,7 @@ PyObject* GetPangoVarAsPython(const std::string& name)
                 return PyString_FromString(val.c_str());
 #endif
             }
-        }catch(std::exception) {
+        }catch(const std::exception&) {
         }
     }
 
@@ -116,7 +116,7 @@ void SetPangoVarFromPython(const std::string& name, PyObject* val)
             pango_var.Meta().gui_changed = true;
         }
         FlagVarChanged();
-    }catch(std::exception e) {
+    }catch(const std::exception& e) {
         pango_print_error("%s\n", e.what());
     }
 }

--- a/include/pangolin/var/var.h
+++ b/include/pangolin/var/var.h
@@ -251,7 +251,7 @@ public:
     {
         try{
             return &(var->Get());
-        }catch(BadInputException)
+        }catch(const BadInputException&)
         {
             Reset();
             return &(var->Get());

--- a/src/tools/video_viewer.cpp
+++ b/src/tools/video_viewer.cpp
@@ -148,7 +148,7 @@ void VideoViewer::Run()
                         images[v], video.Streams()[v].PixFormat(),
                         pangolin::MakeUniqueFilename("capture.png")
                     );
-                }catch(std::exception e){
+                }catch(const std::exception& e){
                     pango_print_error("Unable to save frame: %s\n", e.what());
                 }
             }

--- a/src/var/vars.cpp
+++ b/src/var/vars.cpp
@@ -238,7 +238,7 @@ void SaveJsonFile(const std::string& filename, const string &prefix)
             try{
                 const std::string val = VarState::I()[name]->str->Get();
                 vars[name] = val;
-            }catch(BadInputException)
+            }catch(const BadInputException&)
             {
                 // Ignore things we can't serialise
             }

--- a/src/video/drivers/firewire.cpp
+++ b/src/video/drivers/firewire.cpp
@@ -895,7 +895,7 @@ dc1394video_mode_t get_firewire_mode(unsigned width, unsigned height, const std:
 
             if( w == width && h==height && !fmt.compare(format) )
                 return video_mode;
-        } catch (VideoException e) {}
+        } catch (const VideoException& e) {}
     }
 
     throw VideoException("Unknown video mode");

--- a/src/video/drivers/openni2.cpp
+++ b/src/video/drivers/openni2.cpp
@@ -75,7 +75,7 @@ void OpenNi2Video::PrintOpenNI2Modes(openni::SensorType sensorType)
         std::string sfmt = "PangolinUnknown";
         try{
             sfmt = VideoFormatFromOpenNI2(modes[i].getPixelFormat()).format;
-        }catch(VideoException){}
+        }catch(const VideoException&){}
         pango_print_info( "  %dx%d, %d fps, %s\n",
             modes[i].getResolutionX(), modes[i].getResolutionY(),
             modes[i].getFps(), sfmt.c_str()
@@ -318,7 +318,7 @@ void OpenNi2Video::SetupStreamModes()
         openni::VideoMode onivmode;
         try {
             onivmode = FindOpenNI2Mode(devices[mode.device], nisensortype, mode.dim.x, mode.dim.y, mode.fps, nipixelfmt);
-        }catch(VideoException e) {
+        }catch(const VideoException& e) {
             pango_print_error("Unable to find compatible OpenNI Video Mode. Please choose from:\n");
             PrintOpenNI2Modes(nisensortype);
             fflush(stdout);

--- a/tools/ModelViewer/util.h
+++ b/tools/ModelViewer/util.h
@@ -23,7 +23,7 @@ inline std::vector<Tout> TryLoad(const std::vector<Tin>& in, const F& load_func)
     {
         try {
             loaded.emplace_back(load_func(file));
-        }catch(std::exception) {
+        }catch(const std::exception&) {
         }
     }
     return loaded;

--- a/tools/VideoConvert/main.cpp
+++ b/tools/VideoConvert/main.cpp
@@ -53,7 +53,7 @@ int main( int argc, char* argv[] )
         const std::string output_uri = (argc > 2) ? std::string(argv[2]) : dflt_output_uri;
         try{
             VideoViewer(input_uri, output_uri);
-        } catch (pangolin::VideoException e) {
+        } catch (const pangolin::VideoException& e) {
             std::cout << e.what() << std::endl;
         }
     }else{

--- a/tools/VideoViewer/main.cpp
+++ b/tools/VideoViewer/main.cpp
@@ -10,7 +10,7 @@ int main( int argc, char* argv[] )
         const std::string output_uri = (argc > 2) ? std::string(argv[2]) : dflt_output_uri;
         try{
             pangolin::RunVideoViewerUI(input_uri, output_uri);
-        } catch (pangolin::VideoException e) {
+        } catch (const pangolin::VideoException& e) {
             std::cout << e.what() << std::endl;
         }
     }else{
@@ -43,7 +43,7 @@ int main( int argc, char* argv[] )
                 pango_print_info("Trying: %s\n", input_uris[i].c_str());
                 pangolin::RunVideoViewerUI(input_uris[i], dflt_output_uri);
                 return 0;
-            }catch(pangolin::VideoException) { }
+            }catch(const pangolin::VideoException&) { }
         }
     }
 


### PR DESCRIPTION
This fixes build warnings when compiling with GCC with certain warning flags and improves runtime performance marginally.