### PR TITLE
Fix Eigen issue in ModelViewer

### DIFF
--- a/tools/ModelViewer/main.cpp
+++ b/tools/ModelViewer/main.cpp
@@ -115,8 +115,8 @@ int main( int argc, char** argv )
                 auto geom = future_geom.get();
                 auto aabb = pangolin::GetAxisAlignedBox(geom);
                 total_aabb.extend(aabb);
-                const auto center = total_aabb.center();
-                const auto view = center + Eigen::Vector3f(1.2,1.2,1.2) * std::max( (total_aabb.max() - center).norm(), (center - total_aabb.min()).norm());
+                const Eigen::Vector3f center = total_aabb.center();
+                const Eigen::Vector3f view = center + Eigen::Vector3f(1.2f,1.2f,1.2f) * std::max( (total_aabb.max() - center).norm(), (center - total_aabb.min()).norm());
                 const auto mvm = pangolin::ModelViewLookAt(view[0], view[1], view[2], center[0], center[1], center[2], pangolin::AxisY);
                 s_cam.SetModelViewMatrix(mvm);
                 auto renderable = std::make_shared<GlGeomRenderable>(pangolin::ToGlGeometry(geom), aabb);


### PR DESCRIPTION
I noticed that the ModelViewer tool was crashing for some valid OBJ files and only in a release build, with the following message: 

> terminate called after throwing an instance of 'std::invalid_argument'
  what():  'Look' and 'up' vectors cannot be parallel when calling ModelViewLookAt.

I could trace this down to a _nan_ in the **view** vector here https://github.com/stevenlovegrove/Pangolin/blob/8cd484a782f4f37a7d5ec61cfcbf453ee5f7a12f/tools/ModelViewer/main.cpp#L119 (even though having solely sensible values when calculating the **view** vector).

It turns out that using the _auto_ keyword in combination with Eigen is known to provoke issues, as described in further detail here: https://eigen.tuxfamily.org/dox/TopicPitfalls.html (see: _C++11 and the auto keyword_)

Replacing _auto_ with _Eigen::Vector3f_ fixed the issue. (Btw I tested with Eigen 3.3.7 and 3.3.4)