### PR TITLE
Replace MAC_OS_X_VERSION_10_12 by its value 101200

### DIFF
--- a/src/display/device/PangolinNSApplication.mm
+++ b/src/display/device/PangolinNSApplication.mm
@@ -29,7 +29,7 @@
 #include <pangolin/display/display.h>
 #include <pangolin/display/device/PangolinNSApplication.h>
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
 #  define NSAnyEventMask NSEventMaskAny
 #endif
 

--- a/src/display/device/PangolinNSGLView.mm
+++ b/src/display/device/PangolinNSGLView.mm
@@ -5,7 +5,7 @@
 #include <pangolin/display/display_internal.h>
 #include <pangolin/handler/handler_enums.h>
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
 #  define NSDeviceIndependentModifierFlagsMask NSEventModifierFlagDeviceIndependentFlagsMask
 #  define  NSShiftKeyMask NSEventModifierFlagShift
 #  define  NSControlKeyMask NSEventModifierFlagControl

--- a/src/display/device/display_osx.mm
+++ b/src/display/device/display_osx.mm
@@ -35,7 +35,7 @@
 #include <pangolin/display/device/PangolinNSApplication.h>
 #include <memory>
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
 #  define NSFullScreenWindowMask      NSWindowStyleMaskFullScreen
 #  define NSTitledWindowMask          NSWindowStyleMaskTitled
 #  define NSMiniaturizableWindowMask  NSWindowStyleMaskMiniaturizable


### PR DESCRIPTION
This check was ineffective on macos versions prior to 10.12, since the
constant is not defined there, which caused build failures due to
undefined symbols. By replacing it with the integral value, the
defines should correctly be skipped on macos < 10.12, while behaviour
should remain unchanged on newer versions.

Fixes #327