### PR TITLE
Write DataLog to CSV file

### DIFF
--- a/src/plot/datalog.cpp
+++ b/src/plot/datalog.cpp
@@ -214,10 +214,42 @@ void DataLog::Clear()
     stats.clear();
 }
 
-void DataLog::Save(std::string /*filename*/)
+void DataLog::Save(std::string filename)
 {
-    // TODO: Implement
-    throw std::runtime_error("Method not implemented");
+    std::ofstream csvStream(filename);
+
+      if (!Labels().empty()) {
+        csvStream << Labels()[0];
+
+        for (int i = 1; i < Labels().size(); ++i) {
+          csvStream << "," << Labels()[i];
+        }
+
+        csvStream << std::endl;
+
+    }
+
+    const DataLogBlock * block = FirstBlock();
+
+    while (block) {
+
+      for (int i = 0; i < block->Samples(); ++i) {
+
+        csvStream << block->Sample(i)[0];
+
+        for (int d = 1; d < block->Dimensions(); ++d) {
+
+          csvStream << "," << block->Sample(i)[d];
+
+        }
+
+        csvStream << std::endl;
+
+      }
+
+      block = block->NextBlock();
+
+    }
 }
 
 const DataLogBlock* DataLog::FirstBlock() const


### PR DESCRIPTION
This removes the "not implemented" runtime error and saves a DataLog to csv.