### PR TITLE
Fix mouse press event on some touchscreens on X11

### DIFF
--- a/src/display/device/display_x11.cpp
+++ b/src/display/device/display_x11.cpp
@@ -374,10 +374,9 @@ void X11Window::ProcessEvents()
         case ButtonRelease:
         {
             const int button = ev.xbutton.button-1;
-            const int mask = Button1Mask << button;
             pangolin::process::Mouse(
                 button,
-                ev.xbutton.state & mask,
+                ev.xbutton.type == ButtonRelease,
                 ev.xbutton.x, ev.xbutton.y
             );
             break;


### PR DESCRIPTION
On some touchscreens, mouse press events are recognized as mouse release events.
Fix this by looking at the event type instead of the state to determine if the mouse is pressed.

This seems to be due to something in X11 getting into a bad state

Physical mouse / touch screen in good state:
Press: ev.xbutton.state=0, ev.xbutton.type=4
Release: ev.xbutton.state=256, ev.xbutton.type=5

Touch screen in bad state:
Press: ev.xbutton.state=256, ev.xbutton.type=4
Release: ev.xbutton.state=256, ev.xbutton.type=5