### PR TITLE
fix for more general OBJ file loading

### DIFF
--- a/src/geometry/geometry_obj.cpp
+++ b/src/geometry/geometry_obj.cpp
@@ -49,11 +49,15 @@ struct hash<tinyobj::index_t> {
 
 };
 
-bool operator==(const ::tinyobj::index_t a, const ::tinyobj::index_t b) {
+} // namespace std
+
+namespace tinyobj {
+    
+bool operator==(const index_t a, const index_t b) {
     return a.vertex_index == b.vertex_index && a.normal_index == b.normal_index && a.texcoord_index == b.texcoord_index;
 }
 
-} // namespace std
+} // namespace tinyobj
 
 namespace pangolin {
 


### PR DESCRIPTION
The Pangolin OBJ file loader previously ignored cases in which different indices were used for vertices, normals, and/or textures, which requires reusing the same vertex coordinates with different texture coordinates and/or normals. This change duplicates vertices that are used with different texture and/or normal coordinates and updates the index buffer accordingly.

Furthermore, it seems that the OBJ format assumes textures will be read from bottom to top, causing mismatched texture coordinates. This diff solves this by reading the image and then flipping it vertically, but a further improvement could be to read the inverted image directly.

**Before:**
![Screenshot from 2019-04-11 11-13-30](https://user-images.githubusercontent.com/813541/56004507-9e205880-5c80-11e9-9d09-be45404d5016.png)
This simple OBJ cube file reuses the same 8 vertices and 6 normals, which led to bad results with the existing OBJ loader.

**After:**
![Screenshot from 2019-04-11 16-46-47](https://user-images.githubusercontent.com/813541/56004511-a24c7600-5c80-11e9-9c2f-69f12759477a.png)
The new loader separates vertices as used with different normals leading to the desired result.
