### PR TITLE
Add default move constructor for video_input and video_output

### DIFF
--- a/include/pangolin/video/video_input.h
+++ b/include/pangolin/video/video_input.h
@@ -62,6 +62,7 @@ struct PANGOLIN_EXPORT VideoInput
     /////////////////////////////////////////////////////////////
 
     VideoInput();
+    VideoInput(VideoInput&& other) = default;
     VideoInput(const std::string &input_uri, const std::string &output_uri = "pango:[buffer_size_mb=100]//video_log.pango");
     ~VideoInput();
 

--- a/include/pangolin/video/video_output.h
+++ b/include/pangolin/video/video_output.h
@@ -55,6 +55,7 @@ class PANGOLIN_EXPORT VideoOutput : public VideoOutputInterface
 {
 public:
     VideoOutput();
+    VideoOutput(VideoOutput&& other) = default;
     VideoOutput(const std::string& uri);
     ~VideoOutput();
     


### PR DESCRIPTION
Hi Steven,

this adds default move constructors for `VideoInput` and `VideoOutput`.