### PR TITLE
Unify `CreateWindowAndBind` and `CreateWindowAndBindWithParams`

### DIFF
--- a/src/python/pypangolin/display.cpp
+++ b/src/python/pypangolin/display.cpp
@@ -34,17 +34,12 @@ namespace py_pangolin {
   
   void bind_display(pybind11::module &m) {
     m.def("CreateWindowAndBind",
-          [](const std::string& title, int w=640, int h=480) -> pangolin::WindowInterface& {
-            return pangolin::CreateWindowAndBind(title, w, h);
-          },
+          &pangolin::CreateWindowAndBind,
           pybind11::return_value_policy::reference,
           pybind11::arg("window_title"),
           pybind11::arg("w") = 640,
-          pybind11::arg("h") = 480);
-
-    m.def("CreateWindowAndBindWithParams",
-          &pangolin::CreateWindowAndBind,
-          pybind11::return_value_policy::reference);
+          pybind11::arg("h") = 480,
+          pybind11::arg("params") = pangolin::Params());
 	
     m.def("DestroyWindow",
           &pangolin::DestroyWindow,

--- a/src/python/pypangolin/params.cpp
+++ b/src/python/pypangolin/params.cpp
@@ -35,7 +35,9 @@ namespace py_pangolin {
         .def(pybind11::init<>())
         .def("Contains", &pangolin::Params::Contains)
         .def("Set", &pangolin::Params::Set<int>)
-        .def("Get", &pangolin::Params::Get<int>);
+        .def("Get", &pangolin::Params::Get<int>)
+        .def("Set", &pangolin::Params::Set<std::string>)
+        .def("Get", &pangolin::Params::Get<std::string>);
     }
 
 }  // py_pangolin

--- a/src/python/pypangolin/pypangolin.h
+++ b/src/python/pypangolin/pypangolin.h
@@ -57,11 +57,11 @@ inline void PopulateModule(pybind11::module& m)
     m.doc() = "pypangolin python wrapper for Pangolin rapid prototyping graphics and video library.";
 
     py_pangolin::bind_var(m);
+    py_pangolin::bind_params(m);
     py_pangolin::bind_viewport(m);
     py_pangolin::bind_view(m);
     py_pangolin::bind_window(m);
     py_pangolin::bind_display(m);
-    py_pangolin::bind_params(m);
     py_pangolin::bind_opengl_render_state(m);
     py_pangolin::bind_attach(m);
     py_pangolin::bind_colour(m);


### PR DESCRIPTION
I don't see a good reason to split the C++ function `CreateWindowAndBind` into two functions for the python binding (`CreateWindowAndBind` and `CreateWindowAndBindWithParams`), since it is possible to use the same default parameter for the argument `params` in python. To this end, the binding of `Params` simply has to be provided before the binding of `Display`.

This commit removes the python binding `CreateWindowAndBindWithParams` by providing the same functionality with `CreateWindowAndBind` (as in C++).

Further, the python binding of `Params` supports string types now.

Here is an example of how the two changes can be used:

```python3
import pypangolin as pangolin
params = pangolin.Params()
params.Set("scheme", "headless")
pangolin.CreateWindowAndBind("window", 500, 500, params)
```