### PR TITLE
Fixing a couple of compatibility issues

### DIFF
--- a/src/geometry/geometry_ply.cpp
+++ b/src/geometry/geometry_ply.cpp
@@ -247,7 +247,7 @@ void StandardizeRgbToColor(pangolin::Geometry& geom)
                 Geometry::Element::Attribute& color = verts.attributes["color"];
 
                 // TODO: Check that these really are contiguous in memory...
-                if(auto attrib = mpark::get_if<Image<float>>(&red)) {
+                if(auto attrib = get_if<Image<float>>(&red)) {
                     color = Image<float>(attrib->ptr, have_alpha ? 4 : 3, verts.h, verts.pitch);
                 }else if(auto attrib = get_if<Image<uint8_t>>(&red)) {
                     color = Image<uint8_t>(attrib->ptr, have_alpha ? 4 : 3, verts.h, verts.pitch);

--- a/src/utils/threadedfilebuf.cpp
+++ b/src/utils/threadedfilebuf.cpp
@@ -103,7 +103,7 @@ void threadedfilebuf::close()
 
     if(mem_buffer)
     {
-        delete mem_buffer;
+        delete [] mem_buffer;
         mem_buffer = 0;
     }
 
@@ -142,7 +142,7 @@ std::streamsize threadedfilebuf::xsputn(const char* data, std::streamsize num_by
         }
 
         // Allocate bigger buffer
-        delete mem_buffer;
+        delete [] mem_buffer;
         mem_start = 0;
         mem_end = 0;
         mem_max_size = num_bytes * 4;


### PR DESCRIPTION
1. Fixing an inconsistent usage of 'new []' and 'delete' operators
in utils/threadedfilebuf.cpp.

This inconsistency results in undefined behavior and, potentially,
memory leaks.

2. Removing the explicit 'mpark' namespace specification in
geometry/geometry_ply.cpp.

The `pangolin/geometry/geometry_ply.h -> pangolin/compat/variant.h`
header sequence is supposed to map `get_if` to eiter `std::get_if`
or `mpark::get_if`, depending on the compiler version. This explicit
namespace specification breaks this compatibility behavior.