### PR TITLE
fix Plotter::SetView; not updating target means it zooms back

### DIFF
--- a/src/plot/plotter.cpp
+++ b/src/plot/plotter.cpp
@@ -829,6 +829,8 @@ void Plotter::SetView(const XYRangef& range)
 
     px.rview.x = range.x;
     py.rview.y = range.y;
+    px.target.x = range.x;
+    py.target.y = range.y;
 }
 
 void Plotter::SetViewSmooth(const XYRangef &range)


### PR DESCRIPTION
Without this, SetView is broken. Since target is not updated, the zooming mechanism will go back to the previous view (or current target view) right after calling SetView.