### PR TITLE
Plotter: Add API to reset colour wheel.

### DIFF
--- a/include/pangolin/gl/colour.h
+++ b/include/pangolin/gl/colour.h
@@ -163,6 +163,11 @@ public:
         return GetColourBin(unique_colours++);
     }
 
+    /// Reset colour wheel counter to initial state
+    inline void Reset() {
+      unique_colours = 0;
+    }
+
 protected:
     int unique_colours;
     float sat;

--- a/include/pangolin/plot/plotter.h
+++ b/include/pangolin/plot/plotter.h
@@ -180,6 +180,9 @@ public:
     void ClearImplicitPlots();
     void AddImplicitPlot();
 
+    /// Reset colour wheel to initial state. May be useful together with ClearSeries() / ClearMarkers()
+    void ResetColourWheel();
+
 protected:
     struct PANGOLIN_EXPORT Tick
     {

--- a/src/plot/plotter.cpp
+++ b/src/plot/plotter.cpp
@@ -1161,5 +1161,9 @@ void Plotter::ClearMarkers()
     plotmarkers.clear();
 }
 
+void Plotter::ResetColourWheel()
+{
+    colour_wheel.Reset();
+}
 
 }


### PR DESCRIPTION
Small additional API to reset the colour wheel for a plotter.

This can be useful together with ClearSeries(), when you re-add a set of logs using unspecified color to ensure that they get the same color each time.