### PR TITLE
Jpeg error handler

### DIFF
--- a/include/pangolin/gl/glinclude.h
+++ b/include/pangolin/gl/glinclude.h
@@ -37,9 +37,9 @@
 namespace pangolin {
 inline void _CheckGlDieOnError( const char *sFile, const int nLine )
 {
-    GLenum glError = glGetError();
+    const GLenum glError = glGetError();
     if( glError != GL_NO_ERROR ) {
-        pango_print_error( "OpenGL Error: %s (%x)\n", glErrorString(glError), glError );
+        pango_print_error("OpenGL Error %x: %s\n", glError, glErrorString(glError));
         pango_print_error("In: %s, line %d\n", sFile, nLine);
     }
 }

--- a/include/pangolin/gl/glpangoglu.h
+++ b/include/pangolin/gl/glpangoglu.h
@@ -31,9 +31,8 @@
 
 namespace pangolin {
 
-/// Clone of gluProject
 PANGOLIN_EXPORT
-const GLubyte* glErrorString(GLenum error);
+const char* glErrorString(GLenum error);
 
 /// Clone of gluProject
 PANGOLIN_EXPORT

--- a/src/gl/glpangoglu.cpp
+++ b/src/gl/glpangoglu.cpp
@@ -27,15 +27,25 @@
 
 #include <pangolin/gl/glpangoglu.h>
 #include <pangolin/utils/simple_math.h>
+#include <unordered_map>
 
 namespace pangolin {
 
-const GLubyte gNotErrorLookup[] = "XX";
+// https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetError.xhtml
+static const std::unordered_map<GLenum, std::string> gl_error_string = {
+    {GL_NO_ERROR, "GL_NO_ERROR: No error has been recorded."},
+    {GL_INVALID_ENUM, "GL_INVALID_ENUM: An unacceptable value is specified for an enumerated argument."},
+    {GL_INVALID_VALUE, "GL_INVALID_VALUE: A numeric argument is out of range."},
+    {GL_INVALID_OPERATION, "GL_INVALID_OPERATION: The specified operation is not allowed in the current state."},
+    {GL_INVALID_FRAMEBUFFER_OPERATION, "GL_INVALID_FRAMEBUFFER_OPERATION: The framebuffer object is not complete."},
+    {GL_OUT_OF_MEMORY, "GL_OUT_OF_MEMORY: There is not enough memory left to execute the command."},
+    {GL_STACK_UNDERFLOW, "GL_STACK_UNDERFLOW: An attempt has been made to perform an operation that would cause an internal stack to underflow."},
+    {GL_STACK_OVERFLOW, "GL_STACK_OVERFLOW: An attempt has been made to perform an operation that would cause an internal stack to overflow."},
+};
 
-const GLubyte* glErrorString(GLenum /*error*/)
+const char* glErrorString(GLenum error)
 {
-    // TODO: Implement glErrorString
-    return gNotErrorLookup;
+  return gl_error_string.count(error) ? gl_error_string.at(error).c_str() : nullptr;
 }
 
 // Based on glu implementation.

--- a/src/image/image_io_jpg.cpp
+++ b/src/image/image_io_jpg.cpp
@@ -21,6 +21,12 @@ namespace pangolin {
 
 #ifdef HAVE_JPEG
 
+void error_handler(j_common_ptr cinfo) {
+    char msg[JMSG_LENGTH_MAX];
+    (*(cinfo->err->format_message)) (cinfo, msg);
+    throw std::runtime_error(msg);
+}
+
 const static size_t PANGO_JPEG_BUF_SIZE = 16384;
 
 struct pango_jpeg_source_mgr {
@@ -159,6 +165,7 @@ TypedImage LoadJpg(std::istream& is) {
 
     // Setup decompression structure
     cinfo.err = jpeg_std_error(&jerr);
+    jerr.error_exit = error_handler;
     jpeg_create_decompress(&cinfo);
     pango_jpeg_set_source_mgr(&cinfo, is);
 


### PR DESCRIPTION
Fixes #534 by forwarding the JPEG error to an exception that can be handled by user code. Also includes a fix to print useful OpenGL error messages.