### PR TITLE
var.h print specific Var causing an error

### DIFF
--- a/include/pangolin/var/var.h
+++ b/include/pangolin/var/var.h
@@ -91,7 +91,7 @@ public:
         // Find name in VarStore
         VarValueGeneric*& v = VarState::I()[name];
         if(v) {
-            throw std::runtime_error("Var with that name already exists.");
+            throw std::runtime_error(std::string("Var with the following name already exists: ") + name);
         }else{
             // new VarRef<T> (owned by VarStore)
             VarValue<T&>* nv = new VarValue<T&>(variable);
@@ -114,7 +114,7 @@ public:
         // Find name in VarStore
         VarValueGeneric*& v = VarState::I()[name];
         if (v) {
-            throw std::runtime_error("Var with that name already exists.");
+            throw std::runtime_error(std::string("Var with the following name already exists: ") + name);
         }
         else{
             // new VarRef<T> (owned by VarStore)


### PR DESCRIPTION
This change makes it clear what variable already exists when the runtime error is thrown.

However, I still have the outstanding VideoViewer issue https://github.com/stevenlovegrove/Pangolin/issues/537 which led to this PR:
```
 Var with the following name already exists: ui.frame
```
