### PR TITLE
set policy CMP0072 to prefer GLVND for OpenGL_GL_PREFERENCE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,6 +138,10 @@ if(BUILD_PANGOLIN_GUI AND BUILD_PANGOLIN_VARS AND BUILD_PANGOLIN_VIDEO )
     list(APPEND SOURCES tools/video_viewer.cpp)
 endif()
 
+if(LINUX)
+    set(OpenGL_GL_PREFERENCE "GLVND")
+endif()
+
 #######################################################
 ## Setup required includes / link info
 


### PR DESCRIPTION
Sets CMake policy CMP0072 to silence warning about unspecified `OpenGL_GL_PREFERENCE` for newer cmake > 3.10.