### PR TITLE
fix compile with Mac OS Xcode 11

### DIFF
--- a/include/pangolin/geometry/geometry.h
+++ b/include/pangolin/geometry/geometry.h
@@ -47,7 +47,6 @@ struct Geometry
         Element() = default;
         Element(Element&&) = default;
         Element& operator=(Element&&) = default;
-        Element& operator=(const Element&) = default;
 
         Element(size_t stride_bytes, size_t num_elements)
             : ManagedImage<uint8_t>(stride_bytes, num_elements)

--- a/src/display/device/PangolinNSGLView.mm
+++ b/src/display/device/PangolinNSGLView.mm
@@ -81,8 +81,8 @@ int mapKeymap(int osx_key)
 -(void)reshape
 {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
-    if ( [self wantsBestResolutionOpenGLSurface] && [ _window respondsToSelector:@selector(backingScaleFactor) ] )
-        backing_scale = [_window backingScaleFactor];
+    if ( [self wantsBestResolutionOpenGLSurface] && [ self.window respondsToSelector:@selector(backingScaleFactor) ] )
+        backing_scale = [self.window backingScaleFactor];
     else
 #endif
         backing_scale = 1.0;


### PR DESCRIPTION
This PR fixes the following errors that I get when compiling with Xcode 11 on Mac.

Error 1:
```
/Users/vsu/Pangolin/src/display/device/PangolinNSGLView.mm:84:55: error: use of undeclared identifier '_window'
    if ( [self wantsBestResolutionOpenGLSurface] && [ _window respondsToSelector:@selector(backingScaleFactor) ] )
                                                      ^
/Users/vsu/Pangolin/src/display/device/PangolinNSGLView.mm:85:26: error: use of undeclared identifier '_window'
        backing_scale = [_window backingScaleFactor];
                         ^
2 errors generated.
```

Error 2:
```
/Users/vsu/Pangolin/include/pangolin/geometry/geometry.h:50:18: error: explicitly defaulted copy assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
        Element& operator=(const Element&) = default;
                 ^
/Users/vsu/Pangolin/include/pangolin/geometry/geometry.h:46:22: note: copy assignment operator of 'Element' is implicitly deleted because base class 'ManagedImage<uint8_t>' (aka 'ManagedImage<unsigned char>') has a deleted copy assignment operator
    struct Element : public ManagedImage<uint8_t> {
                     ^
/Users/vsu/Pangolin/include/pangolin/image/managed_image.h:89:5: note: copy assignment operator is implicitly deleted because 'ManagedImage<unsigned char, std::__1::allocator<unsigned char> >' has a user-declared move constructor
    ManagedImage(ManagedImage<T,Allocator>&& img)
    ^
1 error generated.
```