### PR TITLE
Fix indent in GlFormatChannels

### DIFF
--- a/include/pangolin/gl/gl.hpp
+++ b/include/pangolin/gl/gl.hpp
@@ -92,9 +92,9 @@ inline size_t GlDataTypeBytes(GLenum type)
 
 inline size_t GlFormatChannels(GLenum data_layout)
 {
-  if (data_layout == GL_BGR) return 3;
-  if (data_layout == GL_BGRA) return 4;
-  return format_channels[data_layout - GL_RED];
+    if (data_layout == GL_BGR) return 3;
+    if (data_layout == GL_BGRA) return 4;
+    return format_channels[data_layout - GL_RED];
 }
 
 //template<typename T>


### PR DESCRIPTION
I noticed I screwed up the indent in d33757da4be5eddbdf1b434b9251477051578fc5 (PR https://github.com/stevenlovegrove/Pangolin/pull/551), sorry. Merge this one to correct or feel free to close without merging.