### PR TITLE
Implements Colour Providers for the plotter

### DIFF
--- a/examples/SimplePlot/main.cpp
+++ b/examples/SimplePlot/main.cpp
@@ -19,8 +19,21 @@ int main(/*int argc, char* argv[]*/)
 
   const float tinc = 0.01f;
 
+  std::unique_ptr<pangolin::ColourProvider> colours;
+  bool use_wheel = true; /// By default we use a ColourWheel provider
+
+  if (use_wheel) {
+      colours = std::make_unique<pangolin::ColourWheel>(0.6);
+  }
+  else {
+      colours = std::make_unique<pangolin::ColourCircularBuffer>();
+      colours->Add(pangolin::Colour::Green().WithAlpha(0.3f));
+      colours->Add(pangolin::Colour::Green().WithAlpha(0.6f));
+      colours->Add(pangolin::Colour::Green().WithAlpha(0.9f));
+  }
+
   // OpenGL 'view' of data. We might have many views of the same data.
-  pangolin::Plotter plotter(&log,0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
+  pangolin::Plotter plotter(&log, std::move(colours), 0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
   plotter.SetBounds(0.0, 1.0, 0.0, 1.0);
   plotter.Track("$i");
 

--- a/include/pangolin/gl/colour.h
+++ b/include/pangolin/gl/colour.h
@@ -135,11 +135,26 @@ struct Colour
 
 };
 
+/// The base class of colour providers. It does not enforce any strategy on how to provide the colours
+class ColourProvider
+{
+public:
+    /// Adds a colour to this provider. Some providers that generate colours
+    /// might not need to implement this (e.g. ColourWheel)
+    virtual void Add(const Colour& colour) {};
+
+    /// Get next colour. In the case of generation it would create a new one.
+    virtual Colour GetNext() = 0;
+
+    /// Reset colours
+    virtual void Reset() = 0;
+};
+
 /// A ColourWheel is like a continuous colour palate that can be sampled.
 /// In the future, different ColourWheels will be supported, but this one
 /// is based on sampling hues in HSV colourspace. An indefinite number of
 /// unique colours are sampled using the golden angle.
-class ColourWheel
+class ColourWheel : public ColourProvider
 {
 public:
     /// Construct ColourWheel with Saturation, Value and Alpha constant.
@@ -158,13 +173,13 @@ public:
     }
 
     /// Return next unique colour from ColourWheel.
-    inline Colour GetUniqueColour()
+    inline Colour GetNext() override
     {
         return GetColourBin(unique_colours++);
     }
 
     /// Reset colour wheel counter to initial state
-    inline void Reset() {
+    inline void Reset() override {
       unique_colours = 0;
     }
 
@@ -173,6 +188,34 @@ protected:
     float sat;
     float val;
     float alpha;
+};
+
+/// A simple Circular Buffer of colours
+class ColourCircularBuffer : public ColourProvider
+{
+public:
+    /// Adds a new color to the vector
+    virtual void Add(const Colour& colour) override {
+        colours.emplace_back(colour);
+        current_idx = colours.size() - 1;
+    }
+
+    /// Return next colour in the buffer
+    inline Colour GetNext() override
+    {
+        current_idx = (current_idx + 1) % colours.size();
+        return colours[current_idx];
+    }
+
+    /// Clear all added colours
+    inline void Reset() override {
+        colours.clear();
+        current_idx = 0;
+    }
+
+protected:
+    std::vector<Colour> colours;
+    size_t current_idx = 0;
 };
 
 }

--- a/include/pangolin/gl/colour.h
+++ b/include/pangolin/gl/colour.h
@@ -141,7 +141,7 @@ class ColourProvider
 public:
     /// Adds a colour to this provider. Some providers that generate colours
     /// might not need to implement this (e.g. ColourWheel)
-    virtual void Add(const Colour& colour) {};
+    virtual void Add(const Colour& /*colour*/) {};
 
     /// Get next colour. In the case of generation it would create a new one.
     virtual Colour GetNext() = 0;

--- a/include/pangolin/plot/plotter.h
+++ b/include/pangolin/plot/plotter.h
@@ -103,6 +103,7 @@ class PANGOLIN_EXPORT Plotter : public View, Handler
 public:
     Plotter(
         DataLog* default_log,
+        std::unique_ptr<ColourProvider>&& colour_prov,
         float left=0, float right=600, float bottom=-1, float top=1,
         float tickx=30, float ticky=0.5,
         Plotter* linked_plotter_x = 0,
@@ -181,7 +182,7 @@ public:
     void AddImplicitPlot();
 
     /// Reset colour wheel to initial state. May be useful together with ClearSeries() / ClearMarkers()
-    void ResetColourWheel();
+    void ResetColourProvider();
 
 protected:
     struct PANGOLIN_EXPORT Tick
@@ -239,7 +240,7 @@ protected:
 
     DataLog* default_log;
 
-    ColourWheel colour_wheel;
+    std::unique_ptr<ColourProvider> colour_provider;
     Colour colour_bg;
     Colour colour_tk;
     Colour colour_ax;

--- a/src/plot/plotter.cpp
+++ b/src/plot/plotter.cpp
@@ -197,12 +197,13 @@ void Plotter::PlotImplicit::CreateDistancePlot(const std::string& /*dist*/)
 
 Plotter::Plotter(
     DataLog* log,
+    std::unique_ptr<ColourProvider>&& colour_prov,
     float left, float right, float bottom, float top,
     float tickx, float ticky,
     Plotter* linked_plotter_x,
     Plotter* linked_plotter_y
 )   : default_log(log),
-      colour_wheel(0.6f),
+      colour_provider(std::move(colour_prov)),
       rview_default(left,right,bottom,top), rview(rview_default), target(rview),
       selection(0,0,0,0),
       track(false), track_x("$i"), track_y(""),
@@ -1110,7 +1111,7 @@ void Plotter::AddSeries(const std::string& x_expr, const std::string& y_expr,
     const std::string& title, DataLog *log)
 {
     if( !std::isfinite(colour.r) ) {
-        colour = colour_wheel.GetUniqueColour();
+        colour = colour_provider->GetNext();
     }
     plotseries.push_back( PlotSeries() );
     plotseries.back().CreatePlot(x_expr, y_expr, colour, (title == "$y") ? PlotTitleFromExpr(y_expr) : title);
@@ -1163,9 +1164,9 @@ void Plotter::ClearMarkers()
     plotmarkers.clear();
 }
 
-void Plotter::ResetColourWheel()
+void Plotter::ResetColourProvider()
 {
-    colour_wheel.Reset();
+    colour_provider->Reset();
 }
 
 }

--- a/tools/Plotter/main.cpp
+++ b/tools/Plotter/main.cpp
@@ -94,7 +94,7 @@ int main( int argc, char* argv[] )
 
     pangolin::CreateWindowAndBind("Plotter", 640, 480);
 
-    pangolin::Plotter plotter(&log, xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
+    pangolin::Plotter plotter(&log, std::make_unique<pangolin::ColourWheel>(0.6), xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
     if( (bool)args["x"] || (bool)args["y"]) {
         plotter.ClearSeries();
         std::vector<std::string> xvec = pangolin::Split(xs,',');


### PR DESCRIPTION
Adds an abstraction for color providers used by the plotter. ColourWheel becomes a provider, and it also adds a simple ColourCircularBuffer provider

Same as before with the ColourWheel:
![colourwheel](https://user-images.githubusercontent.com/24234483/67492486-c6006800-f676-11e9-9970-530292fd2f61.png)

Using the simple ColourCircularBuffer (and shades of green):
![colour_circular_buffer](https://user-images.githubusercontent.com/24234483/67492587-ee886200-f676-11e9-8303-ea3393cf397b.png)
