### PR TITLE
Feature/colour provider

### DIFF
--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -135,11 +135,26 @@ struct Colour
 
 };
 
+/// The base class of colour providers. It does not enforce any strategy on how to provide the colours
+class ColourProvider
+{
+public:
+    /// Adds a colour to this provider. Some providers that generate colours
+    /// might not need to implement this (e.g. ColourWheel)
+    virtual void Add(const Colour& colour) {};
+
+    /// Get next colour. In the case of generation it would create a new one.
+    virtual Colour GetNext() = 0;
+
+    /// Reset colours
+    virtual void Reset() = 0;
+};
+
 /// A ColourWheel is like a continuous colour palate that can be sampled.
 /// In the future, different ColourWheels will be supported, but this one
 /// is based on sampling hues in HSV colourspace. An indefinite number of
 /// unique colours are sampled using the golden angle.
-class ColourWheel
+class ColourWheel : public ColourProvider
 {
 public:
     /// Construct ColourWheel with Saturation, Value and Alpha constant.
@@ -158,13 +173,13 @@ public:
     }
 
     /// Return next unique colour from ColourWheel.
-    inline Colour GetUniqueColour()
+    inline Colour GetNext() override
     {
         return GetColourBin(unique_colours++);
     }
 
     /// Reset colour wheel counter to initial state
-    inline void Reset() {
+    inline void Reset() override {
       unique_colours = 0;
     }
 
@@ -173,6 +188,34 @@ protected:
     float sat;
     float val;
     float alpha;
+};
+
+/// A simple Circular Buffer of colours
+class ColourCircularBuffer : public ColourProvider
+{
+public:
+    /// Adds a new color to the vector
+    virtual void Add(const Colour& colour) override {
+        colours.emplace_back(colour);
+        current_idx = colours.size() - 1;
+    }
+
+    /// Return next colour in the buffer
+    inline Colour GetNext() override
+    {
+        current_idx = (current_idx + 1) % colours.size();
+        return colours[current_idx];
+    }
+
+    /// Clear all added colours
+    inline void Reset() override {
+        colours.clear();
+        current_idx = 0;
+    }
+
+protected:
+    std::vector<Colour> colours;
+    size_t current_idx = 0;
 };
 
 }

--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -148,6 +148,9 @@ public:
 
     /// Reset colours
     virtual void Reset() = 0;
+
+    /// Virtual destructor to ensure correct destruction of derived classes
+    virtual ~ColourProvider() = default;
 };
 
 /// A ColourWheel is like a continuous colour palate that can be sampled.

--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -176,9 +176,15 @@ public:
     }
 
     /// Return next unique colour from ColourWheel.
-    inline Colour GetNext() override
+    inline Colour GetUniqueColour()
     {
         return GetColourBin(unique_colours++);
+    }
+
+    /// Return next unique colour from ColourWheel for ColorProvider.
+    inline Colour GetNext() override
+    {
+        return GetUniqueColour();
     }
 
     /// Reset colour wheel counter to initial state

--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -141,7 +141,7 @@ class ColourProvider
 public:
     /// Adds a colour to this provider. Some providers that generate colours
     /// might not need to implement this (e.g. ColourWheel)
-    virtual void Add(const Colour& colour) {};
+    virtual void Add(const Colour& /*colour*/) {};
 
     /// Get next colour. In the case of generation it would create a new one.
     virtual Colour GetNext() = 0;

--- a/components/pango_plot/include/pangolin/plot/plotter.h
+++ b/components/pango_plot/include/pangolin/plot/plotter.h
@@ -192,8 +192,14 @@ public:
     void ClearImplicitPlots();
     void AddImplicitPlot();
 
-    /// Reset colour wheel to initial state. May be useful together with ClearSeries() / ClearMarkers()
+    /// Reset colour provider to initial state. May be useful together with ClearSeries() / ClearMarkers()
     void ResetColourProvider();
+
+    /// Alias for ResetColourProvider for API compatibility.
+    void ResetColourWheel()
+    {
+        ResetColourProvider();
+    }
 
     void ShowHoverLines(bool show)
     {

--- a/components/pango_plot/include/pangolin/plot/plotter.h
+++ b/components/pango_plot/include/pangolin/plot/plotter.h
@@ -101,6 +101,17 @@ struct Marker
 class PANGOLIN_EXPORT Plotter : public View, Handler
 {
 public:
+
+    /// Constructor without a colour provider. Defaults to a color wheel
+    Plotter(
+        DataLog* default_log,
+        float left = 0, float right = 600, float bottom = -1, float top = 1,
+        float tickx = 30, float ticky = 0.5,
+        Plotter* linked_plotter_x = 0,
+        Plotter* linked_plotter_y = 0
+    );
+
+    /// Constructor that allows the passing of a colour provider
     Plotter(
         DataLog* default_log,
         std::unique_ptr<ColourProvider>&& colour_prov,

--- a/components/pango_plot/include/pangolin/plot/plotter.h
+++ b/components/pango_plot/include/pangolin/plot/plotter.h
@@ -103,6 +103,7 @@ class PANGOLIN_EXPORT Plotter : public View, Handler
 public:
     Plotter(
         DataLog* default_log,
+        std::unique_ptr<ColourProvider>&& colour_prov,
         float left=0, float right=600, float bottom=-1, float top=1,
         float tickx=30, float ticky=0.5,
         Plotter* linked_plotter_x = 0,
@@ -181,7 +182,7 @@ public:
     void AddImplicitPlot();
 
     /// Reset colour wheel to initial state. May be useful together with ClearSeries() / ClearMarkers()
-    void ResetColourWheel();
+    void ResetColourProvider();
 
     void ShowHoverLines(bool show)
     {
@@ -249,7 +250,7 @@ protected:
 
     DataLog* default_log;
 
-    ColourWheel colour_wheel;
+    std::unique_ptr<ColourProvider> colour_provider;
     Colour colour_bg;
     Colour colour_tk;
     Colour colour_ax;

--- a/components/pango_plot/src/plotter.cpp
+++ b/components/pango_plot/src/plotter.cpp
@@ -198,6 +198,20 @@ void Plotter::PlotImplicit::CreateDistancePlot(const std::string& /*dist*/)
 
 Plotter::Plotter(
     DataLog* log,
+    float left, float right, float bottom, float top,
+    float tickx, float ticky,
+    Plotter* linked_plotter_x,
+    Plotter* linked_plotter_y
+)   : Plotter(log,
+      std::make_unique<pangolin::ColourWheel>(0.6),
+      left,right,bottom,top,
+      tickx, ticky,
+      linked_plotter_x, linked_plotter_y)
+{
+}
+
+Plotter::Plotter(
+    DataLog* log,
     std::unique_ptr<ColourProvider>&& colour_prov,
     float left, float right, float bottom, float top,
     float tickx, float ticky,

--- a/components/pango_plot/src/plotter.cpp
+++ b/components/pango_plot/src/plotter.cpp
@@ -198,12 +198,13 @@ void Plotter::PlotImplicit::CreateDistancePlot(const std::string& /*dist*/)
 
 Plotter::Plotter(
     DataLog* log,
+    std::unique_ptr<ColourProvider>&& colour_prov,
     float left, float right, float bottom, float top,
     float tickx, float ticky,
     Plotter* linked_plotter_x,
     Plotter* linked_plotter_y
 )   : default_log(log),
-      colour_wheel(0.6f),
+      colour_provider(std::move(colour_prov)),
       rview_default(left,right,bottom,top), rview(rview_default), target(rview),
       selection(0,0,0,0),
       track(false), track_x("$i"), track_y(""),
@@ -1113,7 +1114,7 @@ void Plotter::AddSeries(const std::string& x_expr, const std::string& y_expr,
     const std::string& title, DataLog *log)
 {
     if( !std::isfinite(colour.r) ) {
-        colour = colour_wheel.GetUniqueColour();
+        colour = colour_provider->GetNext();
     }
     plotseries.push_back( PlotSeries() );
     plotseries.back().CreatePlot(x_expr, y_expr, colour, (title == "$y") ? PlotTitleFromExpr(y_expr) : title);
@@ -1166,9 +1167,9 @@ void Plotter::ClearMarkers()
     plotmarkers.clear();
 }
 
-void Plotter::ResetColourWheel()
+void Plotter::ResetColourProvider()
 {
-    colour_wheel.Reset();
+    colour_provider->Reset();
 }
 
 }

--- a/examples/SimplePlot/main.cpp
+++ b/examples/SimplePlot/main.cpp
@@ -18,8 +18,21 @@ int main(/*int argc, char* argv[]*/)
 
   const float tinc = 0.01f;
 
+  std::unique_ptr<pangolin::ColourProvider> colours;
+  bool use_wheel = true; /// By default we use a ColourWheel provider
+
+  if (use_wheel) {
+      colours = std::make_unique<pangolin::ColourWheel>(0.6);
+  }
+  else {
+      colours = std::make_unique<pangolin::ColourCircularBuffer>();
+      colours->Add(pangolin::Colour::Green().WithAlpha(0.3f));
+      colours->Add(pangolin::Colour::Green().WithAlpha(0.6f));
+      colours->Add(pangolin::Colour::Green().WithAlpha(0.9f));
+  }
+
   // OpenGL 'view' of data. We might have many views of the same data.
-  pangolin::Plotter plotter(&log,0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
+  pangolin::Plotter plotter(&log, std::move(colours), 0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
   plotter.SetBounds(0.0, 1.0, 0.0, 1.0);
   plotter.Track("$i");
 

--- a/tools/Plotter/main.cpp
+++ b/tools/Plotter/main.cpp
@@ -95,7 +95,7 @@ int main( int argc, char* argv[] )
 
     pangolin::CreateWindowAndBind("Plotter", 640, 480);
 
-    pangolin::Plotter plotter(&log, std::make_unique<pangolin::ColourWheel>(0.6), xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
+    pangolin::Plotter plotter(&log, xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
     if( (bool)args["x"] || (bool)args["y"]) {
         plotter.ClearSeries();
         std::vector<std::string> xvec = pangolin::Split(xs,',');

--- a/tools/Plotter/main.cpp
+++ b/tools/Plotter/main.cpp
@@ -95,7 +95,7 @@ int main( int argc, char* argv[] )
 
     pangolin::CreateWindowAndBind("Plotter", 640, 480);
 
-    pangolin::Plotter plotter(&log, xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
+    pangolin::Plotter plotter(&log, std::make_unique<pangolin::ColourWheel>(0.6), xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
     if( (bool)args["x"] || (bool)args["y"]) {
         plotter.ClearSeries();
         std::vector<std::string> xvec = pangolin::Split(xs,',');


### PR DESCRIPTION
Adds an abstraction for color providers used by the plotter. ColourWheel becomes a provider, and it also adds a simple ColourCircularBuffer provider. The plotter constructor is overloaded to provide backwards compatibility, with the default being a ColourWheel provider (as before).

Same as before with the ColourWheel:
![image](https://user-images.githubusercontent.com/24234483/67689361-7f26b100-f99b-11e9-83a3-5c5308db7bd8.png)

Using the simple ColourCircularBuffer (and shades of green):
![image](https://user-images.githubusercontent.com/24234483/67689379-85b52880-f99b-11e9-84d9-371cce2a1273.png)

The SimplePlot example is updated to showcase how this functionality works:

```
  bool use_wheel = true; /// By default we use a ColourWheel provider

  if (use_wheel) {
      colours = std::make_unique<pangolin::ColourWheel>(0.6);
  }
  else {
      colours = std::make_unique<pangolin::ColourCircularBuffer>();
      colours->Add(pangolin::Colour::Green().WithAlpha(0.3f));
      colours->Add(pangolin::Colour::Green().WithAlpha(0.6f));
      colours->Add(pangolin::Colour::Green().WithAlpha(0.9f));
  }

  // OpenGL 'view' of data. We might have many views of the same data.
  pangolin::Plotter plotter(&log, std::move(colours), 0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);

```