### PR TITLE
cmake: Fix Linux platform check

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,7 +124,7 @@ if(BUILD_PANGOLIN_VIDEO)
     RegisterThreadVideoFactory
   )
 
-  if(LINUX)
+  if(_LINUX_)
     list(APPEND HEADERS ${INCDIR}/video/drivers/shared_memory.h)
     list(APPEND SOURCES video/drivers/shared_memory.cpp)
     # Required for shared memory API using some versions of glibc
@@ -138,7 +138,7 @@ if(BUILD_PANGOLIN_GUI AND BUILD_PANGOLIN_VARS AND BUILD_PANGOLIN_VIDEO )
     list(APPEND SOURCES tools/video_viewer.cpp)
 endif()
 
-if(LINUX)
+if(_LINUX_)
     set(OpenGL_GL_PREFERENCE "GLVND")
 endif()
 


### PR DESCRIPTION
Recently, a new CMake warning concerning OpenGL has been fixed (see #545). However, the variable `LINUX` is not defined which makes the warning still appear. Use `_LINUX_` instead which is defined in `CMakeModules/SetPlatformVars.cmake` to fix this issue.