### PR TITLE
geometry: Add alternative PLY property types

### DIFF
--- a/include/pangolin/geometry/geometry_ply.h
+++ b/include/pangolin/geometry/geometry_ply.h
@@ -39,7 +39,7 @@ namespace pangolin
 #define PLY_GROUP_LIST(m)  m(PlyHeader) m(PlyFormat) m(PlyType)
 #define PLY_HEADER_LIST(m) m(ply) m(format) m(comment) m(property) m(element) m(end_header)
 #define PLY_FORMAT_LIST(m) m(ascii) m(binary_big_endian) m(binary_little_endian)
-#define PLY_TYPE_LIST(m)   m(char) m(uchar) m(short) m(ushort) m(int) m(uint) m(float) m(double) m(list)
+#define PLY_TYPE_LIST(m)   m(char) m(int8) m(uchar) m(uint8) m(short) m(int16) m(ushort) m(uint16) m(int) m(int32) m(uint) m(uint32) m(float) m(float32) m(double) m(float64) m(list)
 
 // Define Enums / strings
 enum PlyHeader {
@@ -63,15 +63,23 @@ enum PlyType {
 #undef FORMAT_ENUM
 };
 const size_t PlyTypeGl[] = {
-//    GL_BYTE, GL_UNSIGNED_BYTE,
-    0x1400, 0x1401,
-//    GL_SHORT, GL_UNSIGNED_SHORT,
-    0x1402, 0x1403,
-//    GL_INT, GL_UNSIGNED_INT,
-    0x1404, 0x1405,
-//    GL_FLOAT, GL_DOUBLE,
-    0x1406, 0x140A,
-//    GL_NONE,
+//  char, int8 -> GL_BYTE
+    0x1400, 0x1400,
+//  uchar, uint8 -> GL_UNSIGNED_BYTE
+    0x1401, 0x1401,
+//  short, int16 -> GL_SHORT
+    0x1402, 0x1402,
+//  ushort, uint16 -> GL_UNSIGNED_SHORT
+    0x1403, 0x1403,
+//  int, int32 -> GL_INT
+    0x1404, 0x1404,
+//  uint, uint32 -> GL_UNSIGNED_INT
+    0x1405, 0x1405,
+//  float, float32 -> GL_FLOAT
+    0x1406, 0x1406,
+//  double, float64 -> GL_DOUBLE
+    0x140A, 0x140A,
+//  list -> GL_NONE
     0
 };
 


### PR DESCRIPTION
The PLY loader defines the set of supported PLY property types. Although all possible scalar types [1] are defined and supported (char, uchar, ..., double), there is also an alternative/alias type [2,3] for each of them (int8,uint8, ..., float64) that is not included here. Since many other libraries and tools support both formats, a user might be confused why certain files that silently use one of these alias types will be rejected by Pangolin. Extend the list of property types to fix this issue.

[1] http://paulbourke.net/dataformats/ply/
[2] http://people.math.sc.edu/Burkardt/data/ply/ply.txt
[3] https://en.wikipedia.org/wiki/PLY_(file_format)