### PR TITLE
[pypangolin] allow multiple args to pangolin::Var

### DIFF
--- a/pyexamples/SimpleDisplay.py
+++ b/pyexamples/SimpleDisplay.py
@@ -1,44 +1,61 @@
 import sys
-sys.path.append('../build/src')
+
+sys.path.append("../build/src")
 
 import pypangolin as pango
 from OpenGL.GL import *
 
+
 def a_callback():
     print("a pressed")
+
 
 def main():
     win = pango.CreateWindowAndBind("pySimpleDisplay", 640, 480)
     glEnable(GL_DEPTH_TEST)
 
-    pm = pango.ProjectionMatrix(640,480,420,420,320,240,0.1,1000);
+    pm = pango.ProjectionMatrix(640, 480, 420, 420, 320, 240, 0.1, 1000)
     mv = pango.ModelViewLookAt(-0, 0.5, -3, 0, 0, 0, pango.AxisY)
     s_cam = pango.OpenGlRenderState(pm, mv)
 
     ui_width = 180
 
-    handler=pango.Handler3D(s_cam)
-    d_cam = pango.CreateDisplay().SetBounds(pango.Attach(0),
-                                            pango.Attach(1),
-                                            pango.Attach.Pix(ui_width),
-                                            pango.Attach(1),
-                                            -640.0/480.0).SetHandler(handler)
+    handler = pango.Handler3D(s_cam)
+    d_cam = (
+        pango.CreateDisplay()
+        .SetBounds(
+            pango.Attach(0),
+            pango.Attach(1),
+            pango.Attach.Pix(ui_width),
+            pango.Attach(1),
+            -640.0 / 480.0,
+        )
+        .SetHandler(handler)
+    )
 
-    pango.CreatePanel("ui").SetBounds( pango.Attach(0),
-                                       pango.Attach(1),
-                                       pango.Attach(0),
-                                       pango.Attach.Pix(ui_width))
-    var_ui=pango.Var("ui")
-    var_ui.A_Button=False
-    var_ui.B_Button=True
-    var_ui.B_Double=1
-    var_ui.B_Str="sss"
-    
-    ctrl=-96
-    pango.RegisterKeyPressCallback(ctrl+ord('a'), a_callback)
-    
+    pango.CreatePanel("ui").SetBounds(
+        pango.Attach(0), pango.Attach(1), pango.Attach(0), pango.Attach.Pix(ui_width)
+    )
+    var_ui = pango.Var("ui")
+    var_ui.a_Button = False
+    var_ui.a_double = (0.0, pango.VarMeta(0, 5))
+    var_ui.an_int = (2, pango.VarMeta(0, 5))
+    var_ui.a_double_log = (3.0, pango.VarMeta(1, 1e4, logscale=True))
+    var_ui.a_checkbox = (False, pango.VarMeta(toggle=True))
+    var_ui.an_int_no_input = 2
+    var_ui.a_str = "sss"
+
+    ctrl = -96
+    pango.RegisterKeyPressCallback(ctrl + ord("a"), a_callback)
+
     while not pango.ShouldQuit():
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+
+        if var_ui.a_checkbox:
+            var_ui.an_int = var_ui.a_double
+
+        var_ui.an_int_no_input = var_ui.an_int
+
         d_cam.Activate(s_cam)
         pango.glDrawColouredCube()
         pango.FinishFrame()

--- a/src/python/pypangolin/var.cpp
+++ b/src/python/pypangolin/var.cpp
@@ -27,96 +27,131 @@
 
 #include "var.hpp"
 #include <functional>
+#include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
 namespace py_pangolin {
 
-  var_t::var_t(const std::string& ns_){
-    if(ns_==""){
-      throw std::invalid_argument("not support empty argument");
-    }
-    ns=ns_+".";
+var_t::var_t(const std::string& ns_){
+  if(ns_==""){
+    throw std::invalid_argument("not support empty argument");
   }
+  ns=ns_+".";
+}
   
-  var_t::~var_t() noexcept{}
+var_t::~var_t() noexcept{}
 
-  var_t::var_t(const var_t &/*other*/){}
-  var_t::var_t(var_t &&/*other*/) noexcept{}
-  var_t& var_t::operator=(const var_t &/*other*/){
-    return *this;
-  }
-  var_t& var_t::operator=(var_t &&/*other*/) noexcept{
-    return *this;
-  }
+var_t::var_t(const var_t &/*other*/){}
 
-  pybind11::object var_t::get_attr(const std::string &name){
-    pangolin::VarState::VarStoreContainer::iterator i = pangolin::VarState::I().vars.find(ns+name);
-    if(i != pangolin::VarState::I().vars.end()) {
-      pangolin::VarValueGeneric* var = i->second;
-      if( !strcmp(var->TypeId(), typeid(bool).name() ) ) {
-        const bool val = pangolin::Var<bool>(*var).Get();
-        return pybind11::bool_(val);
-      }else if( !strcmp(var->TypeId(), typeid(short).name() ) ||
-                !strcmp(var->TypeId(), typeid(int).name() ) ||
-                !strcmp(var->TypeId(), typeid(long).name() ) ) {
-        const long val = pangolin::Var<long>(*var).Get();
-        return pybind11::int_(val);
-      }else if( !strcmp(var->TypeId(), typeid(double).name() ) ||
-                !strcmp(var->TypeId(), typeid(float).name() ) ) {
-        const double val = pangolin::Var<double>(*var).Get();
-        return pybind11::float_(val);
-      }else{
-        const std::string val = var->str->Get();
-        return pybind11::str(val);
-      }
-    }
-    return pybind11::none();
-  }
+var_t::var_t(var_t &&/*other*/) noexcept{}
   
-  template <typename T>
-  void var_t::set_attr_(const std::string& name, T val){
-    pangolin::Var<T> pango_var(ns+name, val);
-    pango_var.Meta().gui_changed = true;
-    pangolin::FlagVarChanged();
+var_t& var_t::operator=(const var_t &/*other*/){
+  return *this;
+}
+
+var_t& var_t::operator=(var_t &&/*other*/) noexcept{
+  return *this;
+}
+
+pybind11::object var_t::get_attr(const std::string &name){
+  pangolin::VarState::VarStoreContainer::iterator i = pangolin::VarState::I().vars.find(ns+name);
+  if (i != pangolin::VarState::I().vars.end()) {
+    pangolin::VarValueGeneric* var = i->second;
+    if (!strcmp(var->TypeId(), typeid(bool).name())) {
+      const bool val = pangolin::Var<bool>(*var).Get();
+      return pybind11::bool_(val);
+    } else if (!strcmp(var->TypeId(), typeid(short).name()) ||
+               !strcmp(var->TypeId(), typeid(int).name()) ||
+               !strcmp(var->TypeId(), typeid(long).name())) {
+      const long val = pangolin::Var<long>(*var).Get();
+      return pybind11::int_(val);
+    } else if (!strcmp(var->TypeId(), typeid(double).name()) ||
+                !strcmp(var->TypeId(), typeid(float).name())) {
+      const double val = pangolin::Var<double>(*var).Get();
+      return pybind11::float_(val);
+    } else {
+      const std::string val = var->str->Get();
+      return pybind11::str(val);
+    }
   }
+  return pybind11::none();
+}
     
-  std::vector<std::string>& var_t::get_members(){
-    const int nss = ns.size();
-    members.clear();
-    for(const std::string& s : pangolin::VarState::I().var_adds) {
-      if(!s.compare(0, nss, ns)) {
-        size_t dot = s.find_first_of('.', nss);
-        members.push_back((dot != std::string::npos) ? s.substr(nss, dot - nss) : s.substr(nss));
-      }
+
+template <typename T>
+void var_t::set_attr_(const std::string& name, T val, const PyVarMeta & meta){
+  pangolin::VarState::VarStoreContainer::iterator i = pangolin::VarState::I().vars.find(ns+name);
+  if (i != pangolin::VarState::I().vars.end()) {
+      pangolin::VarValueGeneric* var = i->second;
+      pangolin::Var<T> v(*var);
+      v = val;
+  } else {
+    int flags = pangolin::META_FLAG_NONE;
+    if (meta.toggle) flags |= pangolin::META_FLAG_TOGGLE;
+    if (meta.read_only)  flags |= pangolin::META_FLAG_READONLY;
+    pangolin::Var<T> pango_var(ns+name, val, flags);
+    pango_var.Meta().gui_changed = true;
+    pango_var.Meta().range[0] = meta.low;
+    pango_var.Meta().range[1] = meta.high;
+    pango_var.Meta().logscale = meta.logscale;
+    pangolin::FlagVarChanged();
+      
+  }
+}
+    
+std::vector<std::string>& var_t::get_members(){
+  const int nss = ns.size();
+  members.clear();
+  for (const std::string& s : pangolin::VarState::I().var_adds) {
+    if (!s.compare(0, nss, ns)) {
+      size_t dot = s.find_first_of('.', nss);
+      members.push_back((dot != std::string::npos) ? s.substr(nss, dot - nss) : s.substr(nss));
     }
-    return members;
   }
-  
-  void bind_var(pybind11::module& m){
-  pybind11::class_<py_pangolin::var_t>(m, "Var")
-    .def(pybind11::init<const std::string &>())
-    .def("__members__", &py_pangolin::var_t::get_members)
+  return members;
+}
 
-    .def("__setattr__", [](var_t& v, const std::string& name, bool val, bool /*toggle*/){
-        v.set_attr_<bool>(name, val);
-      })
+template <typename ... Ts>
+struct VarBinder {
 
-    .def("__setattr__", [](var_t& v, const std::string& name, long val){
-        v.set_attr_<long>(name, val);
-      })
+  static inline void Bind(pybind11::class_<var_t> & varClass) {}
 
-    .def("__setattr__", [](var_t& v, const std::string& name, double val){
-        v.set_attr_<double>(name, val);
-      })
+};
 
-    .def("__setattr__", [](var_t& v, const std::string& name, const std::string& val){
-        v.set_attr_<std::string>(name, val);
-      })
+template <typename Head, typename ... Tail> 
+struct VarBinder<Head, Tail...> {
 
-    .def("__setattr__", [](var_t& v, const std::string& name, std::function<void(void)> val){
-        v.set_attr_<std::function<void(void)> >(name, val);
-      })
+  static inline void Bind(pybind11::class_<var_t> & varClass) {
+      
+    varClass.def("__setattr__", [](var_t& v, const std::string& name, Head val) {
+      v.set_attr_<Head>(name, val);
+    }).def("__setattr__", [](var_t& v, const std::string& name, const std::tuple<Head, PyVarMeta> & valMeta) {
+      v.set_attr_<Head>(name, std::get<0>(valMeta), std::get<1>(valMeta));
+    });
 
-    .def("__getattr__", &py_pangolin::var_t::get_attr);
+    VarBinder<Tail...>::Bind(varClass);
+
   }
+
+};
+
+void bind_var(pybind11::module& m){
+
+  pybind11::class_<PyVarMeta>(m, "VarMeta")
+    .def(pybind11::init<double, double, bool, bool, bool>(), 
+      pybind11::arg("low") = 0.0, 
+      pybind11::arg("high") = 1.0, 
+      pybind11::arg("logscale") = false, 
+      pybind11::arg("toggle") = false,
+      pybind11::arg("read_only") = false);
+
+  pybind11::class_<py_pangolin::var_t> varClass(m, "Var");
+    varClass.def(pybind11::init<const std::string &>())
+      .def("__members__", &py_pangolin::var_t::get_members)
+      .def("__getattr__", &py_pangolin::var_t::get_attr);
+
+  VarBinder<bool, int, double, std::string, std::function<void(void)> >::Bind(varClass);
+
+}
+
 }  // py_pangolin

--- a/src/python/pypangolin/var.hpp
+++ b/src/python/pypangolin/var.hpp
@@ -33,6 +33,13 @@
 
 namespace py_pangolin {
 
+  struct PyVarMeta {
+    double low;
+    double high;
+    bool logscale;
+    bool toggle;
+    bool read_only;
+  };
 
   void bind_var(pybind11::module& m);
   
@@ -44,7 +51,7 @@ namespace py_pangolin {
     pybind11::object get_attr(const std::string &name);
 
     template <typename T>
-    void set_attr_(const std::string& name, T val);
+    void set_attr_(const std::string& name, T val, const PyVarMeta & meta = {});
 
     std::vector<std::string>& get_members();     
   protected:
@@ -56,5 +63,5 @@ namespace py_pangolin {
     std::vector<std::string> members;
     std::string ns;
   };
+  
 }  // py_pangolin
-


### PR DESCRIPTION
Current pypangolin bindings only allow `pangolin::Var<T>` objects to be created with a single parameter of type` T` passed to the constructor. The reason (I assume) is that it is implemented by overriding the Python functionality for setting attributes of an object, which only takes one parameter.

Passing multiple arguments is super useful, as it allows you to change widget types (e.g. button vs checkbox) and set min/max ranges on sliders.

As a way around this without changing the functionality drastically, I created an intermediate Python class called `VarMeta` which serves as a vehicle to pass these additional arguments to the `Var` constructor. Now, a `Var` can be constructed by passing a single object of a supported class (the value), or a 2-element tuple containing the value followed by a `VarMeta` object.
For example, to create a float `Var` with a logarithmic scale, you can now use:
```
var_ui.log_scale = (1e-2, pango.VarMeta(1e-4, 1e-1, logscale=True))
```