### PR TITLE
fix compiler warning on __STDC_FORMAT_MACROS redef

### DIFF
--- a/include/pangolin/utils/picojson.h
+++ b/include/pangolin/utils/picojson.h
@@ -69,7 +69,9 @@ extern "C" {
 
 // experimental support for int64_t (see README.mkdn for detail)
 #ifdef PICOJSON_USE_INT64
-# define __STDC_FORMAT_MACROS
+# ifndef __STDC_FORMAT_MACROS
+#  define __STDC_FORMAT_MACROS
+# endif
 # include <errno.h>
 # include <inttypes.h>
 #endif // PICOJSON_USE_INT64


### PR DESCRIPTION
Without this, if I include 2 libraries that define this macro, I get warnings like

```
warning: '__STDC_FORMAT_MACROS' macro redefined [-Wmacro-redefined]
```

This is on macos 10.15 with AppleClang 11.

See also upstream PR: https://github.com/kazuho/picojson/pull/127