### PR TITLE
Fix mixed up option descriptions in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ SET(CPACK_PACKAGE_VERSION_PATCH "0")
 include(CPack)
 
 option( BUILD_TESTS "Build Tests" ON )
-option( BUILD_TOOLS "Build Examples" ON )
-option( BUILD_EXAMPLES "Build Tools" ON )
+option( BUILD_TOOLS "Build Tools" ON )
+option( BUILD_EXAMPLES "Build Examples" ON )
 
 set (CMAKE_CXX_STANDARD 14)
 


### PR DESCRIPTION
Changes mixed up descriptions in CMakeLists.txt to acutally match the option they describe.