### PR TITLE
fix: Correct hit buffer processing in scenehandler

### DIFF
--- a/include/pangolin/scene/scenehandler.h
+++ b/include/pangolin/scene/scenehandler.h
@@ -57,7 +57,7 @@ struct SceneHandler : public Handler3D
         GLuint closestNumNames = 0;
         GLuint closestZ = std::numeric_limits<GLuint>::max();
         for (int i = 0; i < hits; i++) {
-            if (buf[1] < closestZ) {
+            if (buf[1] < closestZ && buf[0] != 0) {
                 closestNames = buf + 3;
                 closestNumNames = buf[0];
                 closestZ = buf[1];


### PR DESCRIPTION
Unnamed elements should be ignored when looking for the closest hit.

Another option would be to replace ProcessHitBuffer with just

```
        for (int hit = 0; hit < hits; hit++) {
            for(unsigned int name = 0; name < buf[0]; name++) {
                const int pickId = (buf + 3)[name];
                hit_map[pickId] = InteractiveIndex::I().Find(pickId);
            }
            buf += buf[0] + 3;
        }
```

That way every element gets the chance to react to the mouse event. But then it would be better to order them by z distance and stop the Mouse callback calling as soon as one indicated handling (returned true).