### PR TITLE
add macro export difinition of packet and packetstream

### DIFF
--- a/include/pangolin/log/packet.h
+++ b/include/pangolin/log/packet.h
@@ -33,7 +33,7 @@
 namespace pangolin {
 
 // Encapsulate serialized reading of Packet from stream.
-struct Packet
+struct PANGOLIN_EXPORT Packet
 {
     Packet(PacketStream& s, std::unique_lock<std::recursive_mutex>&& mutex, std::vector<PacketStreamSource>& srcs);
     Packet(const Packet&) = delete;

--- a/include/pangolin/log/packetstream.h
+++ b/include/pangolin/log/packetstream.h
@@ -35,7 +35,7 @@
 namespace pangolin
 {
 
-class PacketStream: public std::ifstream
+class PANGOLIN_EXPORT PacketStream: public std::ifstream
 {
 public:
     PacketStream()


### PR DESCRIPTION
To avoid error like "LNK2019	unresolved external symbol "public: __cdecl pangolin::Packet::~Packet(void)" (??1Packet@pangolin@@QEAA@XZ)，" while building the tool "VideoJson"