### PR TITLE
Fix bug where Eigen is not included in CUDA files

### DIFF
--- a/include/pangolin/display/opengl_render_state.h
+++ b/include/pangolin/display/opengl_render_state.h
@@ -279,7 +279,7 @@ TooN::Matrix<4,4> ToTooN(const OpenGlMatrixSpec& ms);
 TooN::SE3<> ToTooN_SE3(const OpenGlMatrixSpec& ms);
 #endif
 
-#ifdef HAVE_EIGEN
+#ifdef USE_EIGEN
 template<typename P>
 Eigen::Matrix<P,4,4> ToEigen(const OpenGlMatrix& ms);
 #endif


### PR DESCRIPTION
Replace `HAVE_EIGEN` with `USE_EIGEN`, so that `Eigen::Matrix<P,4,4> ToEigen(const OpenGlMatrix& ms);` is not defined in CUDA code where Eigen headers are not included.