### PR TITLE
rename python dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
   <buildtool_depend>cmake</buildtool_depend>
   <depend>libglew-dev</depend>
   <depend>cmake</depend>
-  <depend>python</depend>
+  <depend>python3-dev</depend>
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
A small fix in the `package.xml` to be able to release the package to the ROS repo. This also makes the package depend on Python 3 instead of Python 2, assuming that Pangolin is compatible with Python 3.

~~Before going forward with this, is Pangolin compatible with Python 3? In this case, we should probably depend on the newer python version. At the moment the `python-dev` key points to the `python2-dev` package in Ubuntu.~~