### PR TITLE
fix warnings

### DIFF
--- a/src/image/image_io_lz4.cpp
+++ b/src/image/image_io_lz4.cpp
@@ -39,7 +39,7 @@ void SaveLz4(const Image<unsigned char>& image, const pangolin::PixelFormat& fmt
         throw std::runtime_error("A result of 0 for LZ4 means compression worked, but was stopped because the destination buffer couldn't hold all the information.");
 
     lz4_image_header header;
-    strncpy(header.magic,"LZ4",3);
+    memcpy(header.magic,"LZ4",3);
     strncpy(header.fmt, fmt.format.c_str(), sizeof(header.fmt));
     header.w = image.w;
     header.h = image.h;

--- a/src/image/image_io_packed12bit.cpp
+++ b/src/image/image_io_packed12bit.cpp
@@ -39,7 +39,7 @@ void SavePacked12bit(const Image<uint8_t>& image, const pangolin::PixelFormat& f
     }
 
   packed12bit_image_header header;
-  strncpy(header.magic,"P12B",4);
+  memcpy(header.magic,"P12B",4);
   strncpy(header.fmt, fmt.format.c_str(), sizeof(header.fmt));
   header.w = image.w;
   header.h = image.h;

--- a/src/image/image_io_zstd.cpp
+++ b/src/image/image_io_zstd.cpp
@@ -24,7 +24,7 @@ void SaveZstd(const Image<unsigned char>& image, const pangolin::PixelFormat& fm
 #ifdef HAVE_ZSTD
     // Write out header, uncompressed
     zstd_image_header header;
-    strncpy(header.magic,"ZSTD",4);
+    memcpy(header.magic,"ZSTD",4);
     strncpy(header.fmt, fmt.format.c_str(), sizeof(header.fmt));
     header.w = image.w;
     header.h = image.h;

--- a/src/video/drivers/openni.cpp
+++ b/src/video/drivers/openni.cpp
@@ -80,6 +80,7 @@ OpenNiVideo::OpenNiVideo(OpenNiSensorType s1, OpenNiSensorType s2, ImageDim dim,
         switch( sensor_type[i] ) {
         case OpenNiDepth_1mm_Registered:
             depth_to_color = true;
+            [[fallthrough]];
         case OpenNiDepth_1mm:
             use_depth = true;
             break;


### PR DESCRIPTION
Fixes warnings:
- `this statement may fall through [-Wimplicit-fallthrough=]`
- `output truncated before terminating nul copying N bytes from a string of the same length [-Wstringop-truncation]`