### PR TITLE
fix: numeric_limits compilation error

### DIFF
--- a/components/pango_core/src/factory/factory_help.cpp
+++ b/components/pango_core/src/factory/factory_help.cpp
@@ -2,6 +2,7 @@
 #include <numeric>
 #include <pangolin/factory/factory_help.h>
 #include <pangolin/factory/factory_registry.h>
+#include <limits>
 
 namespace pangolin {
 


### PR DESCRIPTION
A small fix for a compilation error with GCC 11.1.0

`numeric_limits` is used in `components/pango_core/src/factory/factory_help.cpp` but the `<limits>` header is not included.