### PR TITLE
re-enable Wayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ include(PangolinFactory)
 
 option( BUILD_TOOLS "Build Tools" ON )
 option( BUILD_EXAMPLES "Build Examples" ON )
+option( BUILD_ASAN "enable AddressSanitizer for Debug builds to detect memory issues" OFF)
 
 # Default build type (Override with cmake .. -DCMAKE_BUILD_TYPE=...)
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -60,6 +61,25 @@ elseif(EMSCRIPTEN)
     set(CMAKE_EXE_LINKER_FLAGS "-sASYNCIFY=1 -sDISABLE_EXCEPTION_CATCHING=0 -sGL_ASSERTIONS=1 -sFULL_ES2=1 -sFULL_ES3=1 --bind")
 else()
     option( BUILD_SHARED_LIBS "Build Shared Library" ON)
+endif()
+
+if (BUILD_ASAN)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} \
+        -fsanitize=address \
+        -fsanitize=bool \
+        -fsanitize=bounds \
+        -fsanitize=enum \
+        -fsanitize=float-cast-overflow \
+        -fsanitize=float-divide-by-zero \
+        -fsanitize=nonnull-attribute \
+        -fsanitize=returns-nonnull-attribute \
+        -fsanitize=signed-integer-overflow \
+        -fsanitize=undefined \
+        -fsanitize=vla-bound \
+        -fno-sanitize=alignment \
+        -fsanitize=leak \
+        -fsanitize=object-size \
+    ")
 endif()
 
 #######################################################

--- a/components/pango_video/src/drivers/openni.cpp
+++ b/components/pango_video/src/drivers/openni.cpp
@@ -80,8 +80,7 @@ OpenNiVideo::OpenNiVideo(OpenNiSensorType s1, OpenNiSensorType s2, ImageDim dim,
         switch( sensor_type[i] ) {
         case OpenNiDepth_1mm_Registered:
             depth_to_color = true;
-            use_depth = true;
-            break;
+            [[fallthrough]];
         case OpenNiDepth_1mm:
             use_depth = true;
             break;

--- a/components/pango_windowing/CMakeLists.txt
+++ b/components/pango_windowing/CMakeLists.txt
@@ -31,6 +31,46 @@ else()
     endif()
     target_compile_definitions(${COMPONENT} PUBLIC "PANGO_DEFAULT_WIN_URI=\"x11\"")
     PangolinRegisterFactory(WindowInterface X11Window)
+
+    # Wayland
+    find_package(Wayland QUIET)
+    if(WAYLAND_CLIENT_FOUND)
+        find_package(PkgConfig)
+        pkg_check_modules(xkbcommon REQUIRED xkbcommon)
+
+        target_sources( ${COMPONENT} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src/display_wayland.cpp )
+#        target_link_libraries(${COMPONENT} PRIVATE ${X11_LIBRARIES} )
+#        target_include_directories(${COMPONENT} PRIVATE ${X11_INCLUDE_DIR} )
+
+        target_link_libraries(${COMPONENT} PRIVATE ${X11_LIBRARIES}
+            ${WAYLAND_CLIENT_LIBRARIES}
+            ${WAYLAND_EGL_LIBRARIES}
+            ${WAYLAND_CURSOR_LIBRARIES}
+            ${egl_LIBRARIES}
+            ${xkbcommon_LIBRARIES}
+        )
+
+        # find Wayland protocols
+        pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
+
+        # find 'wayland-scanner' executable
+        pkg_get_variable(WAYLAND_SCANNER wayland-scanner wayland_scanner)
+
+        # generate protocol implementation
+        set(XDG_PROT_DEF "${WAYLAND_PROTOCOLS_DIR}/stable/xdg-shell/xdg-shell.xml")
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-client-protocol.h
+            COMMAND ${WAYLAND_SCANNER} client-header ${XDG_PROT_DEF} xdg-shell-client-protocol.h)
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-protocol.c
+            COMMAND ${WAYLAND_SCANNER} private-code ${XDG_PROT_DEF} xdg-shell-protocol.c
+            DEPENDS xdg-shell-client-protocol.h)
+        target_include_directories(${COMPONENT} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+        target_sources( ${COMPONENT} PRIVATE xdg-shell-protocol.c)
+
+    endif()
+    target_compile_definitions(${COMPONENT} PUBLIC "PANGO_DEFAULT_WIN_URI=\"wayland\"")
+    PangolinRegisterFactory(WindowInterface WaylandWindow)
 endif()
 
 # headless offscreen rendering via EGL

--- a/components/pango_windowing/src/display_wayland.cpp
+++ b/components/pango_windowing/src/display_wayland.cpp
@@ -475,23 +475,28 @@ static void handle_configure_toplevel(void *data, struct xdg_toplevel */*xdg_top
         main_h = std::max((w->height)-2*int(w->decoration->border_size)-int(w->decoration->title_size), int(min_height));
     }
 
+    w->width = main_w;
+    w->height = main_h;
+}
+
+static void handle_configure(void *data, struct xdg_surface *xdg_surface, uint32_t serial) {
+    WaylandDisplay* const w = static_cast<WaylandDisplay*>(data);
+
     // resize main surface
-    wl_egl_window_resize(w->egl_window, main_w, main_h, 0, 0);
+    wl_egl_window_resize(w->egl_window, w->width, w->height, 0, 0);
 
     // set opaque region
     struct wl_region* wregion = wl_compositor_create_region(w->wcompositor);
-    wl_region_add(wregion, 0, 0, main_w, main_h);
+    wl_region_add(wregion, 0, 0, w->width, w->height);
     wl_surface_set_opaque_region(w->wsurface, wregion);
     wl_region_destroy(wregion);
 
     // resize all decoration elements
-    w->decoration->resize(main_w, main_h);
+    w->decoration->resize(w->width, w->height);
 
     // notify Panglin views about resized area
-    pangolin::process::Resize(main_w, main_h);
-}
+    pangolin::process::Resize(w->width, w->height);
 
-static void handle_configure(void */*data*/, struct xdg_surface *xdg_surface, uint32_t serial) {
     xdg_surface_ack_configure(xdg_surface, serial);
 }
 

--- a/components/pango_windowing/src/display_wayland.cpp
+++ b/components/pango_windowing/src/display_wayland.cpp
@@ -691,7 +691,9 @@ static void keyboard_handle_keymap(void *data, struct wl_keyboard */*keyboard*/,
     d->xkb_state = xkb_state_new(d->keymap);
 }
 
-static void keyboard_handle_enter(void */*data*/, struct wl_keyboard */*keyboard*/, uint32_t /*serial*/, struct wl_surface */*surface*/, struct wl_array */*keys*/) { }
+static void keyboard_handle_enter(void *data, struct wl_keyboard */*keyboard*/, uint32_t /*serial*/, struct wl_surface */*surface*/, struct wl_array */*keys*/) {
+    static_cast<WaylandDisplay*>(data)->flags = {};
+}
 
 static void keyboard_handle_leave(void */*data*/, struct wl_keyboard */*keyboard*/, uint32_t /*serial*/, struct wl_surface */*surface*/) { }
 

--- a/components/pango_windowing/src/display_wayland.cpp
+++ b/components/pango_windowing/src/display_wayland.cpp
@@ -307,6 +307,16 @@ struct Decoration {
         return resize_cursor.count((enum xdg_toplevel_resize_edge)last_type) ? resize_cursor.at((enum xdg_toplevel_resize_edge)last_type) : "left_ptr";
     }
 
+    void toContentSize(const int window_w, const int window_h, int &content_w, int &content_h) {
+        content_w = window_w - (2*border_size);
+        content_h = window_h - (2*border_size + title_size);
+    }
+
+    void toWindowSize(const int content_w, const int content_h, int &window_w, int &window_h) {
+        window_w = content_w + (2*border_size);
+        window_h = content_h + (2*border_size + title_size);
+    }
+
     std::vector<DecorationSurface> decorations;
     int last_type;
 
@@ -501,10 +511,11 @@ static void handle_configure_toplevel(void *data, struct xdg_toplevel */*xdg_top
     if (restore_w==0) restore_w = w->width;
     if (restore_h==0) restore_h = w->height;
 
-    if(!w->is_fullscreen) {
+    if(!w->is_fullscreen && (width!=0 && height!=0)) {
         // has decoration
-        w->width = std::max(restore_w-int(2*w->decoration->border_size), int(min_width));
-        w->height = std::max(restore_h-2*int(w->decoration->border_size)-int(w->decoration->title_size), int(min_height));
+        w->decoration->toContentSize(restore_w, restore_h, w->width, w->height);
+        w->width = std::max(w->width, int(min_width));
+        w->height = std::max(w->height, int(min_height));
     }
     else {
         w->width = restore_w;

--- a/components/pango_windowing/src/display_wayland.cpp
+++ b/components/pango_windowing/src/display_wayland.cpp
@@ -18,9 +18,7 @@
 #include <unistd.h>
 #include <cstdlib>
 
-#if USE_WL_XDG
 #include <xdg-shell-client-protocol.h>
-#endif
 
 #define WAYLAND_VERSION_GE(MAJ, MIN) WAYLAND_VERSION_MAJOR >= MAJ && WAYLAND_VERSION_MINOR >= MIN
 
@@ -30,16 +28,16 @@ extern __thread PangolinGl* context;
 
 namespace wayland {
 
-static const std::map<enum wl_shell_surface_resize, std::string> resize_cursor = {
-    {WL_SHELL_SURFACE_RESIZE_NONE, "grabbing"},
-    {WL_SHELL_SURFACE_RESIZE_TOP, "top_side"},
-    {WL_SHELL_SURFACE_RESIZE_BOTTOM, "bottom_side"},
-    {WL_SHELL_SURFACE_RESIZE_LEFT, "left_side"},
-    {WL_SHELL_SURFACE_RESIZE_TOP_LEFT, "top_left_corner"},
-    {WL_SHELL_SURFACE_RESIZE_BOTTOM_LEFT, "bottom_left_corner"},
-    {WL_SHELL_SURFACE_RESIZE_RIGHT, "right_side"},
-    {WL_SHELL_SURFACE_RESIZE_TOP_RIGHT, "top_right_corner"},
-    {WL_SHELL_SURFACE_RESIZE_BOTTOM_RIGHT, "bottom_right_corner"}
+static const std::map<enum xdg_toplevel_resize_edge, std::string> resize_cursor = {
+    {XDG_TOPLEVEL_RESIZE_EDGE_NONE, "grabbing"},
+    {XDG_TOPLEVEL_RESIZE_EDGE_TOP, "top_side"},
+    {XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM, "bottom_side"},
+    {XDG_TOPLEVEL_RESIZE_EDGE_LEFT, "left_side"},
+    {XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT, "top_left_corner"},
+    {XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT, "bottom_left_corner"},
+    {XDG_TOPLEVEL_RESIZE_EDGE_RIGHT, "right_side"},
+    {XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT, "top_right_corner"},
+    {XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT, "bottom_right_corner"},
 };
 
 struct ButtonSurface {
@@ -136,12 +134,12 @@ struct DecorationSurface {
     uint border_size;
     uint title_bar_size;
 
-    enum wl_shell_surface_resize function;
+    enum xdg_toplevel_resize_edge function;
 
     DecorationSurface(wl_compositor* compositor, wl_subcompositor* subcompositor,
                       wl_surface* source, EGLDisplay egl_display, EGLConfig config,
                       const uint _border_size, const uint _title_bar_size,
-                      enum wl_shell_surface_resize type, pangolin::Colour _colour
+                      enum xdg_toplevel_resize_edge type, pangolin::Colour _colour
                       ) :
         egl_display(egl_display),
         colour(_colour),
@@ -169,39 +167,39 @@ struct DecorationSurface {
     void calc_dim(const int main_w, const int main_h, int &x, int &y, int &w, int &h) const {
         // get position and dimension from type and main surface
         switch (function) {
-        case WL_SHELL_SURFACE_RESIZE_NONE:
+        case XDG_TOPLEVEL_RESIZE_EDGE_NONE:
             x=0; y=-title_bar_size;
             w=main_w; h=title_bar_size;
             break;
-        case WL_SHELL_SURFACE_RESIZE_TOP:
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP:
             x=0; y=-title_bar_size-border_size;
             w=main_w; h=border_size;
             break;
-        case WL_SHELL_SURFACE_RESIZE_BOTTOM:
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:
             x=0; y=main_h;
             w=main_w; h=border_size;
             break;
-        case WL_SHELL_SURFACE_RESIZE_LEFT:
+        case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:
             x=-border_size; y=-title_bar_size;
             w=border_size; h=main_h+title_bar_size;
             break;
-        case WL_SHELL_SURFACE_RESIZE_TOP_LEFT:
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:
             x=-border_size; y=-border_size-title_bar_size;
             w=border_size; h=border_size;
             break;
-        case WL_SHELL_SURFACE_RESIZE_BOTTOM_LEFT:
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:
             x=-border_size; y=main_h;
             w=border_size; h=border_size;
             break;
-        case WL_SHELL_SURFACE_RESIZE_RIGHT:
+        case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:
             x=main_w; y=-title_bar_size;
             w=border_size; h=main_h+title_bar_size;
             break;
-        case WL_SHELL_SURFACE_RESIZE_TOP_RIGHT:
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:
             x=main_w; y=-border_size-title_bar_size;
             w=border_size; h=border_size;
             break;
-        case WL_SHELL_SURFACE_RESIZE_BOTTOM_RIGHT:
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT:
             x=main_w; y=main_h;
             w=border_size; h=border_size;
             break;
@@ -249,19 +247,19 @@ struct Decoration {
         decorations.reserve(9);
 
         // title bar, 2D movement
-        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, WL_SHELL_SURFACE_RESIZE_NONE, colour);
+        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, XDG_TOPLEVEL_RESIZE_EDGE_NONE, colour);
 
         // sides, 1D resizing
-        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, WL_SHELL_SURFACE_RESIZE_LEFT, colour);
-        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, WL_SHELL_SURFACE_RESIZE_RIGHT, colour);
-        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, WL_SHELL_SURFACE_RESIZE_TOP, colour);
-        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, WL_SHELL_SURFACE_RESIZE_BOTTOM, colour);
+        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, XDG_TOPLEVEL_RESIZE_EDGE_LEFT, colour);
+        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, XDG_TOPLEVEL_RESIZE_EDGE_RIGHT, colour);
+        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, XDG_TOPLEVEL_RESIZE_EDGE_TOP, colour);
+        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM, colour);
 
         // corners, 2D resizing
-        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, WL_SHELL_SURFACE_RESIZE_TOP_LEFT, colour);
-        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, WL_SHELL_SURFACE_RESIZE_TOP_RIGHT, colour);
-        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, WL_SHELL_SURFACE_RESIZE_BOTTOM_LEFT, colour);
-        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, WL_SHELL_SURFACE_RESIZE_BOTTOM_RIGHT, colour);
+        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT, colour);
+        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT, colour);
+        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT, colour);
+        decorations.emplace_back(compositor, subcompositor, surface, egl_display, config, border_size, title_size, XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT, colour);
 
         // buttons
         buttons.reserve(2);
@@ -302,7 +300,7 @@ struct Decoration {
     }
 
     const std::string getCursorForCurrentSurface() const {
-        return resize_cursor.count((enum wl_shell_surface_resize)last_type) ? resize_cursor.at((enum wl_shell_surface_resize)last_type) : "left_ptr";
+        return resize_cursor.count((enum xdg_toplevel_resize_edge)last_type) ? resize_cursor.at((enum xdg_toplevel_resize_edge)last_type) : "left_ptr";
     }
 
     std::vector<DecorationSurface> decorations;
@@ -337,14 +335,9 @@ struct WaylandDisplay {
     struct wl_subcompositor *wsubcompositor = nullptr;
     struct wl_surface *wsurface = nullptr;
     struct wl_egl_window *egl_window = nullptr;
-#if USE_WL_XDG
     struct xdg_wm_base *xshell = nullptr;
     struct xdg_surface *xshell_surface = nullptr;
     struct xdg_toplevel *xshell_toplevel = nullptr;
-#else
-    struct wl_shell *wshell = nullptr;
-    struct wl_shell_surface *wshell_surface = nullptr;
-#endif
 
     struct wl_seat *wseat = nullptr;
     struct wl_keyboard *wkeyboard = nullptr;
@@ -453,11 +446,7 @@ static const std::map<uint,int> wl_key_special_ids = {
     {KEY_INSERT, PANGO_KEY_INSERT},
 };
 
-#if USE_WL_XDG
 static void handle_configure_toplevel(void *data, struct xdg_toplevel */*xdg_toplevel*/, int32_t width, int32_t height, struct wl_array */*states*/) {
-#else
-static void handle_configure(void *data, struct wl_shell_surface */*shell_surface*/, uint32_t /*edges*/, int32_t width, int32_t height) {
-#endif
 
     const static uint min_width = 70;
     const static uint min_height = 70;
@@ -502,7 +491,6 @@ static void handle_configure(void *data, struct wl_shell_surface */*shell_surfac
     pangolin::process::Resize(main_w, main_h);
 }
 
-#if USE_WL_XDG
 static void handle_configure(void */*data*/, struct xdg_surface *xdg_surface, uint32_t serial) {
     xdg_surface_ack_configure(xdg_surface, serial);
 }
@@ -527,19 +515,6 @@ static void xdg_wm_base_ping(void */*data*/, struct xdg_wm_base *xdg_wm_base, ui
 static const struct xdg_wm_base_listener shell_listener = {
     .ping = xdg_wm_base_ping
 };
-#else
-static void handle_ping(void */*data*/, struct wl_shell_surface *shell_surface, uint32_t serial) {
-    wl_shell_surface_pong(shell_surface, serial);
-}
-
-static void handle_popup_done(void */*data*/, struct wl_shell_surface */*shell_surface*/) { }
-
-static const struct wl_shell_surface_listener shell_surface_listener = {
-    handle_ping,
-    handle_configure,
-    handle_popup_done
-};
-#endif
 
 static void pointer_handle_enter(void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t /*sx*/, wl_fixed_t /*sy*/) {
     WaylandDisplay* const w = static_cast<WaylandDisplay*>(data);
@@ -588,26 +563,18 @@ static void pointer_handle_button(void *data, struct wl_pointer */*wl_pointer*/,
         // resizing using window decoration
         if((button==BTN_LEFT) && (state==WL_POINTER_BUTTON_STATE_PRESSED)) {
             switch (w->decoration->last_type) {
-            case WL_SHELL_SURFACE_RESIZE_NONE:
-#if USE_WL_XDG
+            case XDG_TOPLEVEL_RESIZE_EDGE_NONE:
                 xdg_toplevel_move(w->xshell_toplevel, w->wseat, serial);
-#else
-                wl_shell_surface_move(w->wshell_surface, w->wseat, serial);
-#endif
                 break;
-            case WL_SHELL_SURFACE_RESIZE_TOP:
-            case WL_SHELL_SURFACE_RESIZE_BOTTOM:
-            case WL_SHELL_SURFACE_RESIZE_LEFT:
-            case WL_SHELL_SURFACE_RESIZE_TOP_LEFT:
-            case WL_SHELL_SURFACE_RESIZE_BOTTOM_LEFT:
-            case WL_SHELL_SURFACE_RESIZE_RIGHT:
-            case WL_SHELL_SURFACE_RESIZE_TOP_RIGHT:
-            case WL_SHELL_SURFACE_RESIZE_BOTTOM_RIGHT:
-#if USE_WL_XDG
+            case XDG_TOPLEVEL_RESIZE_EDGE_TOP:
+            case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:
+            case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:
+            case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:
+            case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:
+            case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:
+            case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:
+            case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT:
                 xdg_toplevel_resize(w->xshell_toplevel, w->wseat, serial, w->decoration->last_type);
-#else
-                wl_shell_surface_resize(w->wshell_surface, w->wseat, serial, w->decoration->last_type);
-#endif
                 break;
             case ButtonSurface::type::CLOSE:
                 pangolin::QuitAll();
@@ -615,23 +582,10 @@ static void pointer_handle_button(void *data, struct wl_pointer */*wl_pointer*/,
             case ButtonSurface::type::MAXIMISE:
                 w->is_maximised = !w->is_maximised;
                 if(w->is_maximised) {
-#if USE_WL_XDG
                     xdg_toplevel_set_maximized(w->xshell_toplevel);
-#else
-                    // store original window size
-                    wl_egl_window_get_attached_size(w->egl_window, &w->width, &w->height);
-                    wl_shell_surface_set_maximized(w->wshell_surface, nullptr);
-#endif
                 }
                 else {
-#if USE_WL_XDG
                     xdg_toplevel_unset_maximized(w->xshell_toplevel);
-#else
-                    wl_shell_surface_set_toplevel(w->wshell_surface);
-                    handle_configure(data, nullptr, 0,
-                                     w->width+2*w->decoration->border_size,
-                                     w->height+2*w->decoration->border_size+w->decoration->title_size);
-#endif
                 }
 
                 break;
@@ -795,15 +749,9 @@ static void global_registry_handler(void *data, struct wl_registry *registry, ui
     else if (strcmp(interface, wl_subcompositor_interface.name) == 0) {
         w->wsubcompositor = static_cast<wl_subcompositor*>(wl_registry_bind(registry, id, &wl_subcompositor_interface, version));
     }
-#if USE_WL_XDG
     else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
         w->xshell = reinterpret_cast<xdg_wm_base*> (wl_registry_bind(registry, id, &xdg_wm_base_interface, version));
     }
-#else
-    else if (strcmp(interface, wl_shell_interface.name) == 0) {
-        w->wshell = reinterpret_cast<wl_shell*> (wl_registry_bind(registry, id, &wl_shell_interface, version));
-    }
-#endif
     else if (strcmp(interface, wl_seat_interface.name) == 0) {
         w->wseat = reinterpret_cast<wl_seat*>(wl_registry_bind(registry, id, &wl_seat_interface, version));
         wl_seat_add_listener(w->wseat, &seat_listener, data);
@@ -870,17 +818,10 @@ WaylandDisplay::WaylandDisplay(const int width, const int height, const std::str
         std::cerr << "Cannot create EGL surface" << std::endl;
     }
 
-    if(
-#if USE_WL_XDG
-    xshell
-#else
-    wshell
-#endif
-    ==nullptr) {
+    if(xshell==nullptr) {
         throw std::runtime_error("No Wayland shell available!");
     }
 
-#if USE_WL_XDG
     xdg_wm_base_add_listener(xshell, &shell_listener, this);
     xshell_surface = xdg_wm_base_get_xdg_surface(xshell, wsurface);
     xdg_surface_add_listener(xshell_surface, &shell_surface_listener, this);
@@ -888,13 +829,6 @@ WaylandDisplay::WaylandDisplay(const int width, const int height, const std::str
     xdg_toplevel_add_listener(xshell_toplevel, &toplevel_listener, this);
     xdg_toplevel_set_title(xshell_toplevel, title.c_str());
     xdg_toplevel_set_app_id(xshell_toplevel, title.c_str());
-#else
-    wshell_surface = wl_shell_get_shell_surface(wshell, wsurface);
-    wl_shell_surface_add_listener(wshell_surface, &shell_surface_listener, this);
-    wl_shell_surface_set_toplevel(wshell_surface);
-    wl_shell_surface_set_title(wshell_surface, title.c_str());
-    wl_shell_surface_set_class(wshell_surface, title.c_str());
-#endif
 
     wl_display_sync(wdisplay);
 
@@ -915,14 +849,9 @@ WaylandDisplay::~WaylandDisplay() {
     if(egl_display) eglTerminate(egl_display);
 
     // cleanup Wayland
-#if USE_WL_XDG
     if(xshell_surface)  xdg_surface_destroy(xshell_surface);
     if(xshell_toplevel) xdg_toplevel_destroy(xshell_toplevel);
     if(xshell)          xdg_wm_base_destroy(xshell);
-#else
-    if(wshell_surface)  wl_shell_surface_destroy(wshell_surface);
-    if(wshell)          wl_shell_destroy(wshell);
-#endif
 
     if(wsurface)        wl_surface_destroy(wsurface);
     if(wregistry)       wl_registry_destroy(wregistry);
@@ -952,30 +881,11 @@ void WaylandWindow::ToggleFullscreen() {
     display->is_fullscreen = is_fullscreen; // state for Wayland
     if(is_fullscreen) {
         display->decoration->destroy();
-#if USE_WL_XDG
         xdg_toplevel_set_fullscreen(display->xshell_toplevel, nullptr);
-#else
-        wl_shell_surface_set_fullscreen(display->wshell_surface, WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT, 0, nullptr);
-#endif
     }
     else {
         display->decoration->create();
-#if USE_WL_XDG
         xdg_toplevel_unset_fullscreen(display->xshell_toplevel);
-#else
-        wl_shell_surface_set_toplevel(display->wshell_surface);
-#endif
-
-#if !USE_WL_XDG
-        if(display->is_maximised) {
-            wl_shell_surface_set_maximized(display->wshell_surface, nullptr);
-        }
-        else {
-            handle_configure(static_cast<void*>(display.get()), nullptr, 0,
-                             windowed_size[0]+2*display->decoration->border_size,
-                             windowed_size[1]+2*display->decoration->border_size+display->decoration->title_size);
-        }
-#endif
     }
 
     wl_display_sync(display->wdisplay);

--- a/components/pango_windowing/src/display_wayland.cpp
+++ b/components/pango_windowing/src/display_wayland.cpp
@@ -73,7 +73,6 @@ struct ButtonSurface {
     {
         surface = wl_compositor_create_surface(compositor);
         subsurface = wl_subcompositor_get_subsurface(subcompositor, surface, source);
-        wl_subsurface_set_desync(subsurface);
         egl_context = eglCreateContext (egl_display, config, EGL_NO_CONTEXT, nullptr);
         egl_window = wl_egl_window_create(surface, width, height);
         egl_surface = eglCreateWindowSurface(egl_display, config, (EGLNativeWindowType)egl_window, nullptr);
@@ -123,6 +122,7 @@ struct ButtonSurface {
             glEnd();
             break;
         }
+        eglSwapInterval(egl_display, 0);
         eglSwapBuffers(egl_display, egl_surface);
     }
 };
@@ -153,7 +153,6 @@ struct DecorationSurface {
     {
         surface = wl_compositor_create_surface(compositor);
         subsurface = wl_subcompositor_get_subsurface(subcompositor, surface, source);
-        wl_subsurface_set_desync(subsurface);
         egl_context = eglCreateContext(egl_display, config, EGL_NO_CONTEXT, nullptr);
         egl_window = wl_egl_window_create(surface, 50, 50);
         egl_surface = eglCreateWindowSurface(egl_display, config, (EGLNativeWindowType)egl_window, nullptr);
@@ -221,6 +220,7 @@ struct DecorationSurface {
         eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context);
         glClearColor(colour.r, colour.g, colour.b, colour.a);
         glClear(GL_COLOR_BUFFER_BIT);
+        eglSwapInterval(egl_display, 0);
         eglSwapBuffers(egl_display, egl_surface);
     }
 };
@@ -971,7 +971,7 @@ void WaylandWindow::SwapBuffers() {
 
     MakeCurrent();
 
-    wl_display_roundtrip(display->wdisplay);
+    wl_display_dispatch(display->wdisplay);
 }
 
 

--- a/components/pango_windowing/src/display_wayland.cpp
+++ b/components/pango_windowing/src/display_wayland.cpp
@@ -372,7 +372,6 @@ struct WaylandDisplay {
         EGL_RED_SIZE        , 8,
         EGL_GREEN_SIZE      , 8,
         EGL_BLUE_SIZE       , 8,
-        EGL_ALPHA_SIZE      , 8,
         EGL_DEPTH_SIZE      , 24,
         EGL_STENCIL_SIZE    , 8,
         EGL_NONE
@@ -484,12 +483,6 @@ static void handle_configure(void *data, struct xdg_surface *xdg_surface, uint32
 
     // resize main surface
     wl_egl_window_resize(w->egl_window, w->width, w->height, 0, 0);
-
-    // set opaque region
-    struct wl_region* wregion = wl_compositor_create_region(w->wcompositor);
-    wl_region_add(wregion, 0, 0, w->width, w->height);
-    wl_surface_set_opaque_region(w->wsurface, wregion);
-    wl_region_destroy(wregion);
 
     // resize all decoration elements
     w->decoration->resize(w->width, w->height);
@@ -838,7 +831,7 @@ WaylandDisplay::WaylandDisplay(const int width, const int height, const std::str
     wl_display_sync(wdisplay);
 
     // construct window decoration
-    const pangolin::Colour grey(0.5f, 0.5f, 0.5f, 0.5f);
+    const pangolin::Colour grey(0.5f, 0.5f, 0.5f);
     decoration = std::unique_ptr<Decoration>(new Decoration(5, 20, grey, wcompositor, wsubcompositor, wsurface, egl_display, egl_configs[0]));
     decoration->create();
     decoration->resize(width, height);


### PR DESCRIPTION
This re-enables the Wayland `WindowInterface` with some additional fixes. As before, this is automatically enabled at compile time when the wayland development libraries are found. At runtime, it will first check if a wayland display server Is running and if not (or another error occurs during initialisation) it will fall back to X11.

I also added a new CMake variable `BUILD_ASAN` that enables the [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) to check for memory issues in Debug builds.