### PR TITLE
set only one default win URI handler and prefer Wayland over X11

### DIFF
--- a/components/pango_windowing/CMakeLists.txt
+++ b/components/pango_windowing/CMakeLists.txt
@@ -28,9 +28,8 @@ else()
         target_sources( ${COMPONENT} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src/display_x11.cpp )
         target_link_libraries(${COMPONENT} PRIVATE ${X11_LIBRARIES} )
         target_include_directories(${COMPONENT} PRIVATE ${X11_INCLUDE_DIR} )
+        PangolinRegisterFactory(WindowInterface X11Window)
     endif()
-    target_compile_definitions(${COMPONENT} PUBLIC "PANGO_DEFAULT_WIN_URI=\"x11\"")
-    PangolinRegisterFactory(WindowInterface X11Window)
 
     # Wayland
     find_package(Wayland QUIET)
@@ -69,6 +68,8 @@ else()
         # register window factory
         target_compile_definitions(${COMPONENT} PUBLIC "PANGO_DEFAULT_WIN_URI=\"wayland\"")
         PangolinRegisterFactory(WindowInterface WaylandWindow)
+    else()
+        target_compile_definitions(${COMPONENT} PUBLIC "PANGO_DEFAULT_WIN_URI=\"x11\"")
     endif()
 endif()
 


### PR DESCRIPTION
- set only a single `PANGO_DEFAULT_WIN_URI`
- set to `x11` only of not build with Wayland
- set to `wayland` if built with Wayland support, so that Wayland will be preferred automatically and fall back to X11
- Fixes #709 