### PR TITLE
skip wayland if wayland-protocols version is not sufficient

### DIFF
--- a/components/pango_windowing/CMakeLists.txt
+++ b/components/pango_windowing/CMakeLists.txt
@@ -33,7 +33,8 @@ else()
 
     # Wayland
     find_package(Wayland QUIET)
-    if(WAYLAND_CLIENT_FOUND)
+    pkg_check_modules(wayland-protocols QUIET wayland-protocols>=1.13)
+    if(WAYLAND_CLIENT_FOUND AND wayland-protocols_FOUND)
         find_package(PkgConfig)
         pkg_check_modules(xkbcommon REQUIRED xkbcommon)
 


### PR DESCRIPTION
On older Ubuntu versions (16.04) `wayland-protocols` is missing `wayland-protocols`. This will attempt the Wayland build but fail. Check for the version and skip wayland insufficient. Fixes #714.