### PR TITLE
Extend python interface

### DIFF
--- a/components/pango_python/src/pypangolin/gl_draw.cpp
+++ b/components/pango_python/src/pypangolin/gl_draw.cpp
@@ -93,7 +93,19 @@ namespace py_pangolin {
     m.def("glDrawLineLoop", &pangolin::glDrawLineLoop<double, 3, std::allocator<Eigen::Vector3d> >);
 
     m.def("glDrawAlignedBox", (void (*)(const Eigen::AlignedBox2f &, GLenum)) &pangolin::glDrawAlignedBox<float>, pybind11::arg("box"), pybind11::arg("mode") = GL_TRIANGLE_FAN);
+ 
+    m.def("glDrawCirclePerimeter", (void (*)(float, float, float)) &pangolin::glDrawCirclePerimeter);
+    m.def("glDrawCirclePerimeter", (void (*)(const Eigen::Vector2d &, double)) &pangolin::glDrawCirclePerimeter);
 
+    m.def("glDrawRectPerimeter", &pangolin::glDrawRectPerimeter);
+
+    m.def("glDrawCross",  (void (*)(GLfloat, GLfloat, GLfloat)) &pangolin::glDrawCross);
+    m.def("glDrawCross",  (void (*)(GLfloat, GLfloat, GLfloat, GLfloat)) &pangolin::glDrawCross);
+    m.def("glDrawCross",  (void (*)(const Eigen::Vector2d &, double)) &pangolin::glDrawCross);
+    m.def("glDrawCross",  (void (*)(const Eigen::Vector3d &, double)) &pangolin::glDrawCross);
+
+    m.def("glDrawCircle", (void (*)(float, float, float)) &pangolin::glDrawCircle);
+    m.def("glDrawCircle", (void (*)(const Eigen::Vector2d &, double)) &pangolin::glDrawCircle);
   }
 
 

--- a/components/pango_python/src/pypangolin/image_view.cpp
+++ b/components/pango_python/src/pypangolin/image_view.cpp
@@ -35,16 +35,47 @@ namespace py_pangolin {
     using namespace pangolin;
     pybind11::class_<ImageView, View>(m, "ImageView")
       .def(pybind11::init<>())
-      .def("SetImage", [](ImageView& view, pybind11::array_t<float>& img) -> ImageView&{
+      .def("SetImage", [](ImageView& view, pybind11::array_t<float>& img, const std::string & format) -> ImageView&{
         if(img.ndim() == 2) {
-            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.shape(1) * sizeof(float));
-            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString("GRAY32F")) );
+            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.strides(0));
+            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString(format.empty() ? "GRAY32F" : format)) );
         }else if(img.ndim() == 3 && img.shape()[2] == 3) {
-            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), 3 * img.shape(1) * sizeof(float));
-            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString("RGB96F")) );
+            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.strides(0));
+            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString(format.empty() ? "RGB96F" : format)) );
+        }else if(img.ndim() == 3 && img.shape()[2] == 4) {
+            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.strides(0));
+            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString(format.empty() ? "RGB128F" : format)) );
         }else{
             throw std::runtime_error("Unsupported format for now.");
         }
-      });
+      }, "Set image to display by ImageView", pybind11::arg("img"), pybind11::arg("format") = "")
+      .def("SetImage", [](ImageView& view, pybind11::array_t<uint8_t>& img, const std::string & format) -> ImageView&{
+        if(img.ndim() == 2) {
+            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.strides(0));
+            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString(format.empty() ? "GRAY8" : format)) );
+        }else if(img.ndim() == 3 && img.shape()[2] == 3) {
+            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.strides(0));
+            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString(format.empty() ? "RGB24" : format)) );
+        }else if(img.ndim() == 3 && img.shape()[2] == 4) {
+            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.strides(0));
+            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString(format.empty() ? "RGB32" : format)) );
+        }else{
+            throw std::runtime_error("Unsupported format for now.");
+        }
+      }, "Set image to display by ImageView", pybind11::arg("img"), pybind11::arg("format") = "")
+      .def("SetImage", [](ImageView& view, pybind11::array_t<uint16_t>& img, const std::string & format) -> ImageView&{
+        if(img.ndim() == 2) {
+            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.strides(0));
+            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString(format.empty() ? "GRAY16" : format)) );
+        }else if(img.ndim() == 3 && img.shape()[2] == 3) {
+            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.strides(0));
+            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString(format.empty() ? "RGB48" : format)) );
+        }else if(img.ndim() == 3 && img.shape()[2] == 4) {
+            Image<uint8_t> wrapper((uint8_t*)img.mutable_data(0,0), img.shape(1), img.shape(0), img.strides(0));
+            return view.SetImage(wrapper, GlPixFormat(PixelFormatFromString(format.empty() ? "RGB64" : format)) );
+        }else{
+            throw std::runtime_error("Unsupported format for now.");
+        }
+      }, "Set image to display by ImageView", pybind11::arg("img"), pybind11::arg("format") = "");
   }
 }  // py_pangolin

--- a/components/pango_python/src/pypangolin/var.cpp
+++ b/components/pango_python/src/pypangolin/var.cpp
@@ -120,6 +120,18 @@ void var_t::set_attr_(const std::string& name, T val, const PyVarMeta & meta){
     pango_var.Meta().logscale = meta.logscale;
   }
 }
+
+
+pybind11::object var_t::gui_changed(const std::string &name){
+    const std::shared_ptr<pangolin::VarValueGeneric> var = pangolin::VarState::I().GetByName(namespace_prefix+name);
+    if(var) {
+        bool result = var->Meta().gui_changed;
+        var->Meta().gui_changed = false;
+        return pybind11::bool_(result);
+    }
+    return pybind11::none();
+}
+
     
 std::vector<std::string>& var_t::get_members(){
     return members;
@@ -162,7 +174,8 @@ void bind_var(pybind11::module& m){
   pybind11::class_<py_pangolin::var_t> varClass(m, "Var");
     varClass.def(pybind11::init<const std::string &>())
       .def("__members__", &py_pangolin::var_t::get_members)
-      .def("__getattr__", &py_pangolin::var_t::get_attr);
+      .def("__getattr__", &py_pangolin::var_t::get_attr)
+      .def("GuiChanged", &py_pangolin::var_t::gui_changed);
 
   VarBinder<bool, int, double, std::string, std::function<void(void)> >::Bind(varClass);
 

--- a/components/pango_python/src/pypangolin/var.hpp
+++ b/components/pango_python/src/pypangolin/var.hpp
@@ -55,6 +55,8 @@ namespace py_pangolin {
     template <typename T>
     void set_attr_(const std::string& name, T val, const PyVarMeta & meta = {});
 
+    pybind11::object gui_changed(const std::string &name);
+
     std::vector<std::string>& get_members();     
   protected:
     var_t(const var_t &other);

--- a/examples/PythonExamples/SimpleDisplay.py
+++ b/examples/PythonExamples/SimpleDisplay.py
@@ -36,6 +36,7 @@ def main():
     )
     var_ui = pango.Var("ui")
     var_ui.a_Button = False
+    var_ui.a_Toggle = (False, pango.VarMeta(toggle=True))
     var_ui.a_double = (0.0, pango.VarMeta(0, 5))
     var_ui.an_int = (2, pango.VarMeta(0, 5))
     var_ui.a_double_log = (3.0, pango.VarMeta(1, 1e4, logscale=True))
@@ -52,7 +53,8 @@ def main():
         if var_ui.a_checkbox:
             var_ui.an_int = var_ui.a_double
 
-        var_ui.an_int_no_input = var_ui.an_int
+        if var_ui.GuiChanged('an_int'):
+            var_ui.an_int_no_input = var_ui.an_int
 
         d_cam.Activate(s_cam)
         pango.glDrawColouredCube()


### PR DESCRIPTION
This PR extends the python interface of pangolin:
* more functions from `gldraw`.
* Support for `uint8_t` and `uint16_t` image types in `ImageView.SetView`.
* Expose `GuiChanged` for variables in python. Similar to C++ version it resets the flag on read.
*  Update python example to showcase `GuiChanged` and `Toggle`.