### PR TITLE
implement getters for width and height

### DIFF
--- a/components/pango_video/include/pangolin/video/drivers/mjpeg.h
+++ b/components/pango_video/include/pangolin/video/drivers/mjpeg.h
@@ -63,6 +63,9 @@ public:
     size_t GetTotalFrames() const override;
     size_t Seek(size_t frameid) override;
 
+    size_t Width() const { return next_image.w; }
+    size_t Height() const { return next_image.h; }
+
 protected:
     bool LoadNext();
 


### PR DESCRIPTION
I also noticed that `MjpegVideo` it's not well exposed to the global library namespace.

Besides, the `GetCurrentFrameId()` seems to return 0 all the time.