### PR TITLE
Small fix for python interface. Fixes SetDrawFunction in View.

### DIFF
--- a/components/pango_python/src/pypangolin/view.cpp
+++ b/components/pango_python/src/pypangolin/view.cpp
@@ -29,6 +29,7 @@
 #include <pangolin/display/view.h>
 #include <pangolin/gl/opengl_render_state.h>
 #include <pangolin/handler/handler.h>
+#include <pybind11/functional.h>
 
 namespace py_pangolin {
 


### PR DESCRIPTION
Fixes `SetDrawFunction` for `View` in python interface by adding `pybind11/functional.h` headers.