### PR TITLE
Add image rotation option to handler_image

### DIFF
--- a/components/pango_display/include/pangolin/handler/handler_image.h
+++ b/components/pango_display/include/pangolin/handler/handler_image.h
@@ -70,6 +70,11 @@ public:
 
     void glSetViewOrtho();
 
+    // This functions sets the model view matrix so that
+    // the subsequent draw functions can use the texture pixels coordinates.
+    // This corrects for the rotation stored in the thetaQuarterTurn.
+    void glSetModelView();
+
     void glRenderTexture(pangolin::GlTexture& tex);
     void glRenderTexture(GLuint tex, GLint width, GLint height);
 
@@ -113,6 +118,11 @@ public:
 
     void ResetView();
 
+    /// Get the current rotation applied to the texture before drawing
+    int GetThetaQuarterTurn();
+    /// Set the current rotation applied to the texture before drawing
+    virtual void SetThetaQuarterTurn(int _thetaQuarterTurn);
+
     ///////////////////////////////////////////////////////
     /// pangolin::Handler
     ///////////////////////////////////////////////////////
@@ -140,10 +150,20 @@ protected:
 
     void AdjustTranslation();
 
+    void ScreenToScaledViewPort(Viewport& v, float xpix, float ypix_screen, float& x_vp, float& y_vp);
+    void ScaledViewPortToScreen(Viewport& v, float x_vp, float y_vp, float& xpix_screen, float& ypix_screen);
+    void ScaledViewPortToImg(float xsv, float ysv, float& ximg, float& yimg);
+    void ImgToScaledViewPort(float ximg, float yimg, float& xsv, float& ysv);
+    void SetRviewDefaultAndMax();
+
     static ImageViewHandler* to_link;
     static float animate_factor;
 
     ImageViewHandler* linked_view_handler;
+
+    // keep the size of the original image around
+    int original_img_width;
+    int original_img_height;
 
     pangolin::XYRangef rview_default;
     pangolin::XYRangef rview_max;
@@ -151,14 +171,19 @@ protected:
     pangolin::XYRangef target;
     pangolin::XYRangef selection;
 
+    // coordinate in the viewport
+    float hover_vp[2];
+    // coordinate in the image/texture
     float hover_img[2];
     int last_mouse_pos[2];
 
     bool use_nn;
     bool flipTextureX;
     bool flipTextureY;
-    std::string title;
 
+    // The number of 90deg rotations to apply to the texture before displaying.
+    int thetaQuarterTurn;
+    std::string title;
 };
 
 }


### PR DESCRIPTION
This adds methods to rotate the texture before display in handler_image. Rotation are multiple of 90degrees and can be set by using the `SetThetaQuarterTurn` method.

This changes takes care of making the mouse interaction consistent with the rotation for instance when selecting.
The user should call "glSetModelView" before rendering opengl primitive in the original pixel grid. The function will apply the correction rotation.

Test:
As example, here is a random image draw with the four possible orientations. We draw a white line between pixel (0,0) and (1,1).
With every chosen rotation, the line is correctly displayed.
![Screenshot from 2022-05-14 17-13-40](https://user-images.githubusercontent.com/1500089/168452377-1b76aded-4a80-4c5b-8e33-870de1a569bb.png)
![Screenshot from 2022-05-14 17-13-23](https://user-images.githubusercontent.com/1500089/168452378-8b24d8e0-1627-4662-8dcf-ee7ae736c91b.png)
![Screenshot from 2022-05-14 17-13-09](https://user-images.githubusercontent.com/1500089/168452380-41287be8-4b1d-4a2d-97da-3ffcd912a2fb.png)
![Screenshot from 2022-05-14 17-12-52](https://user-images.githubusercontent.com/1500089/168452381-20b2701e-5d84-4ded-90aa-c62fe555805c.png)

Code snippet for testing:
```c++
#include <limits>
#include <iostream>

#include <pangolin/display/display.h>
#include <pangolin/display/view.h>
#include <pangolin/handler/handler.h>
#include <pangolin/handler/handler_image.h>
#include <pangolin/gl/gldraw.h>

void setImageData(unsigned char * imageArray, int size){
  for(int i = 0 ; i < size;i++) {
    imageArray[i] = (unsigned char)(rand()/(RAND_MAX/255.0));
  }
}

int main(/*int argc, char* argv[]*/)
{
  // Create OpenGL window in single line
  pangolin::CreateWindowAndBind("Main",640,480);

  // 3D Mouse handler requires depth testing to be enabled
  glEnable(GL_DEPTH_TEST);
  
  pangolin::OpenGlRenderState s_cam(
    pangolin::ProjectionMatrix(640,480,420,420,320,240,0.1,1000),
    pangolin::ModelViewLookAt(-1,1,-1, 0,0,0, pangolin::AxisY)
  );

  // Aspect ratio allows us to constrain width and height whilst fitting within specified
  // bounds. A positive aspect ratio makes a view 'shrink to fit' (introducing empty bars),
  // whilst a negative ratio makes the view 'grow to fit' (cropping the view).
  pangolin::View& d_cam = pangolin::Display("cam")
      .SetBounds(0,1.0f,0,1.0f,-640/480.0)
      .SetHandler(new pangolin::Handler3D(s_cam));

  // This view will take up no more than a third of the windows width or height, and it
  // will have a fixed aspect ratio to match the image that it will display. When fitting
  // within the specified bounds, push to the top-left (as specified by SetLock).
  pangolin::View& d_image = pangolin::Display("image")
      .SetBounds(2/3.0f,1.0f,0,1/3.0f,1.f)
      .SetLock(pangolin::LockLeft, pangolin::LockTop);

  std::cout << "Resize the window to experiment with SetBounds, SetLock and SetAspect." << std::endl;
  std::cout << "Notice that the cubes aspect is maintained even though it covers the whole screen." << std::endl;

  const int width =  5;
  const int height = 5;

  unsigned char* imageArray = new unsigned char[3*width*height];
  pangolin::GlTexture imageTexture(width,height,GL_RGB,false,0,GL_RGB,GL_UNSIGNED_BYTE);
  pangolin::ImageViewHandler handler(width, height);
  d_image.SetHandler(&handler);
  // Default hooks for exiting (Esc) and fullscreen (tab).
  setImageData(imageArray,3*width*height);
  int i = 0;
  while(!pangolin::ShouldQuit())
  {
    glDisable(GL_DEPTH_TEST);
    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
    //Set some random image data and upload to GPU
    imageTexture.Upload(imageArray,GL_RGB,GL_UNSIGNED_BYTE);
    //display the image
    d_image.Activate();
    glColor3f(1.0,1.0,1.0);
    //imageTexture.RenderToViewport();
    handler.SetThetaQuarterTurn(i/60);
    handler.UpdateView();
    handler.glSetViewOrtho();
    handler.UseNN() = true;
    handler.glRenderTexture(imageTexture);
    handler.glRenderOverlay();
    handler.glSetModelView();
    pangolin::glDrawLine(0,0,1,1);
    pangolin::FinishFrame();
    i++;
  }

  delete[] imageArray;

  return 0;
}
```
