### PR TITLE
CI for ROS (catkin/colcon) workspaces

### DIFF
--- a/.github/workflows/ros_workspace.yml
+++ b/.github/workflows/ros_workspace.yml
@@ -1,0 +1,44 @@
+name: ROS workspace CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # test multiple Ubuntu and ROS distributions
+    # https://github.com/ros-tooling/setup-ros#iterating-on-all-ros-distributions-for-all-platforms
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ros_distribution: [noetic, humble]
+        include:
+          - docker_image: ubuntu:20.04
+            ros_distribution: noetic
+            ros_version: 1
+
+          - docker_image: ubuntu:22.04
+            ros_distribution: humble
+            ros_version: 2
+
+    container:
+      image: ${{ matrix.docker_image }}
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - name: Setup ROS environment
+        uses: ros-tooling/setup-ros@v0.3
+
+      - name: ROS 1 CI Action
+        if: ${{ matrix.ros_version == 1 }}
+        uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          package-name: pangolin
+          target-ros1-distro: ${{ matrix.ros_distribution }}
+
+      - name: ROS 2 CI Action
+        if: ${{ matrix.ros_version == 2 }}
+        uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          package-name: pangolin
+          target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <depend>libglew-dev</depend>
   <depend>cmake</depend>
   <depend>python3-dev</depend>
+  <build_depend>eigen</build_depend>
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,6 @@
   <license>MIT</license>
   <buildtool_depend>cmake</buildtool_depend>
   <depend>libglew-dev</depend>
-  <depend>cmake</depend>
   <depend>python3-dev</depend>
   <build_depend>eigen</build_depend>
   <export>

--- a/package.xml
+++ b/package.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0"?>
-<!-- ROS Catkin package.xml file -->
 <package format="2">
   <name>pangolin</name>
-  <version>0.7.0</version>
-  <description>pangolin</description>
+  <version>0.8.0</version>
+  <description>Pangolin is a set of lightweight and portable utility libraries for prototyping 3D, numeric or video based programs and algorithms.</description>
   <maintainer email="stevenlovegrove@gmail.com">Steven Lovegrove</maintainer>
   <author     email="stevenlovegrove@gmail.com">Steven Lovegrove</author>
   <license>MIT</license>
+
   <buildtool_depend>cmake</buildtool_depend>
+
   <depend>libglew-dev</depend>
   <depend>python3-dev</depend>
   <build_depend>eigen</build_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
This adds CI for building the `pangolin` package as part of a catkin or colcon workspace. This makes sure that the dependencies are properly resolved by the `package.xml` and that it builds correctly with the default setup.