### PR TITLE
added missing include for std::min

### DIFF
--- a/components/pango_image/src/image_io_packed12bit.cpp
+++ b/components/pango_image/src/image_io_packed12bit.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <fstream>
 #include <memory>
 


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/algorithm/min

The image component fails to build on win 10 using cmake to generate a VS2019 solution without including algorithm.