### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ To contribute to Pangolin, I would appreciate pull requests against the master b
 
 
 
+## Installing Pangolin(vcpkg) ##
+
+You can download and install Pangolin using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install Pangolin
+
+The Pangolin port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Extensibility & Factories
 
 Pangolin uses an extensible factory mechanism for modularising video drivers, windowing backends and console interpreters. Concrete instances are instantiated from a particular factory using a URI string which identifies which factory to use and what parameters it should use. As strings, URI's are a useful mechanism for providing and validating configuration from an end user. The URI form is:

--- a/README.md
+++ b/README.md
@@ -147,15 +147,15 @@ To contribute to Pangolin, I would appreciate pull requests against the master b
 
 ## Installing Pangolin(vcpkg) ##
 
-You can download and install Pangolin using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+You can download and install pangolin using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 
     git clone https://github.com/Microsoft/vcpkg.git
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
-    ./vcpkg install Pangolin
+    ./vcpkg install pangolin
 
-The Pangolin port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The pangolin port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Extensibility & Factories
 


### PR DESCRIPTION
`pangolin `is available as a port in vcpkg, a C++ library manager that simplifies installation for `pangolin` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build pangolin, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/pangolin/portfile.cmake). We try to keep the library maintained as close as possible to the original library.