### PR TITLE
ASAN fix for range

### DIFF
--- a/components/pango_core/include/pangolin/utils/range.h
+++ b/components/pango_core/include/pangolin/utils/range.h
@@ -207,7 +207,23 @@ struct Range
     template<typename To>
     Range<To> Cast() const
     {
-        return Range<To>(To(min), To(max));
+        To clampedMin, clampedMax;
+
+        if (min == std::numeric_limits<T>::lowest()){
+          clampedMin = std::numeric_limits<To>::lowest();
+        }
+        else {
+          clampedMin = To(min);
+        }
+
+        if (max == std::numeric_limits<T>::max()){
+          clampedMax = std::numeric_limits<To>::max();
+        }
+        else {
+          clampedMax = To(max);
+        }
+
+        return Range<To>(clampedMin, clampedMax);
     }
 
     T min;

--- a/components/pango_core/include/pangolin/utils/range.h
+++ b/components/pango_core/include/pangolin/utils/range.h
@@ -66,8 +66,8 @@ struct Range
     }
 
     Range()
-        : min(+std::numeric_limits<T>::max()),
-          max(-std::numeric_limits<T>::max())
+        : min(std::numeric_limits<T>::max()),
+          max(std::numeric_limits<T>::lowest())
     {
     }
 


### PR DESCRIPTION
Basically float::max cast to int is too big for that type and it gets sad. Even worse, float doesn't have precision to store even close to int max, meaning you can't just do a std::min() trick to clamp the value. 