### PR TITLE
Add GlFont and GlText to python interface.

### DIFF
--- a/components/pango_python/CMakeLists.txt
+++ b/components/pango_python/CMakeLists.txt
@@ -23,6 +23,8 @@ if(BUILD_PANGOLIN_PYTHON AND Python_FOUND AND pybind11_FOUND)
         ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/display.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/gl.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/gl_draw.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/gltext.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/glfont.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/glsl.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/glvbo.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/handler.cpp

--- a/components/pango_python/src/pypangolin/glfont.cpp
+++ b/components/pango_python/src/pypangolin/glfont.cpp
@@ -1,0 +1,47 @@
+/* This file is part of the Pangolin Project.
+ * http://github.com/stevenlovegrove/Pangolin
+ *
+ * Copyright (c) Andrey Mnatsakanov
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "glfont.hpp"
+#include <pangolin/gl/glfont.h>
+#include <pangolin/display/default_font.h>
+#include <pybind11/eigen.h>
+#include <pybind11/stl.h>
+
+namespace py_pangolin {
+
+  void bind_glfont(pybind11::module &m){
+
+    pybind11::class_<pangolin::GlFont> glFontClass(m, "GlFont");
+    glFontClass.def(pybind11::init<std::string&, float, int, int>())
+      .def("Text", (pangolin::GlText (pangolin::GlFont::*)(const std::string&))&pangolin::GlFont::Text)
+      .def("Height", &pangolin::GlFont::Height)
+      .def("MaxWidth", &pangolin::GlFont::MaxWidth)
+      .def_static("DefaultFont", &pangolin::default_font);
+  }
+
+
+}  // py_pangolin

--- a/components/pango_python/src/pypangolin/glfont.cpp
+++ b/components/pango_python/src/pypangolin/glfont.cpp
@@ -40,7 +40,7 @@ namespace py_pangolin {
       .def("Text", (pangolin::GlText (pangolin::GlFont::*)(const std::string&))&pangolin::GlFont::Text)
       .def("Height", &pangolin::GlFont::Height)
       .def("MaxWidth", &pangolin::GlFont::MaxWidth)
-      .def_static("DefaultFont", &pangolin::default_font);
+      .def_static("DefaultFont", &pangolin::default_font, pybind11::return_value_policy::reference);
   }
 
 

--- a/components/pango_python/src/pypangolin/glfont.hpp
+++ b/components/pango_python/src/pypangolin/glfont.hpp
@@ -1,0 +1,37 @@
+/* This file is part of the Pangolin Project.
+ * http://github.com/stevenlovegrove/Pangolin
+ *
+ * Copyright (c) Andrey Mnatsakanov
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_pangolin {
+  
+  void bind_glfont(pybind11::module &m);
+
+}  // py_pangolin
+

--- a/components/pango_python/src/pypangolin/gltext.cpp
+++ b/components/pango_python/src/pypangolin/gltext.cpp
@@ -1,0 +1,53 @@
+/* This file is part of the Pangolin Project.
+ * http://github.com/stevenlovegrove/Pangolin
+ *
+ * Copyright (c) Andrey Mnatsakanov
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "gltext.hpp"
+#include <pangolin/gl/gltext.h>
+#include <pybind11/eigen.h>
+#include <pybind11/stl.h>
+
+namespace py_pangolin {
+
+  void bind_gltext(pybind11::module &m){
+
+    pybind11::class_<pangolin::GlText> glTextClass(m, "GlText");
+    glTextClass.def(pybind11::init<>())
+      .def("AddSpace", &pangolin::GlText::AddSpace)
+      .def("Add", &pangolin::GlText::Add)
+      .def("Clear", &pangolin::GlText::Clear)
+      .def("Draw", (void (pangolin::GlText::*)() const) &pangolin::GlText::Draw)
+      .def("DrawGlSl", &pangolin::GlText::DrawGlSl)
+      .def("Draw", (void (pangolin::GlText::*)(GLfloat, GLfloat, GLfloat) const) &pangolin::GlText::Draw, pybind11::arg("x"), pybind11::arg("y"), pybind11::arg("z") = 0)
+      .def("DrawWindow", &pangolin::GlText::DrawWindow)
+      .def("Text", &pangolin::GlText::Text)
+      .def("Width", &pangolin::GlText::Width)
+      .def("Height", &pangolin::GlText::Height)
+      .def("FullHeight", &pangolin::GlText::FullHeight);
+  }
+
+
+}  // py_pangolin

--- a/components/pango_python/src/pypangolin/gltext.hpp
+++ b/components/pango_python/src/pypangolin/gltext.hpp
@@ -1,0 +1,38 @@
+/* This file is part of the Pangolin Project.
+ * http://github.com/stevenlovegrove/Pangolin
+ *
+ * Copyright (c) Andrey Mnatsakanov
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_pangolin {
+  
+  void bind_gltext(pybind11::module &m);
+  
+
+}  // py_pangolin
+

--- a/components/pango_python/src/pypangolin/pypangolin.h
+++ b/components/pango_python/src/pypangolin/pypangolin.h
@@ -38,6 +38,8 @@
 #include "gl.hpp"
 #include "glsl.hpp"
 #include "gl_draw.hpp"
+#include "gltext.hpp"
+#include "glfont.hpp"
 #include "glvbo.hpp"
 #include "handler.hpp"
 #include "image.hpp"
@@ -76,6 +78,8 @@ inline void PopulateModule(pybind11::module& m)
     py_pangolin::bind_glsl(m);
     py_pangolin::bind_gl_draw(m);
     py_pangolin::bind_glvbo(m);
+    py_pangolin::bind_glfont(m);
+    py_pangolin::bind_gltext(m);
     py_pangolin::bind_widget(m);
     py_pangolin::bind_pixel_format(m);
     py_pangolin::bind_image<unsigned char>(m, "Image");

--- a/components/pango_python/src/pypangolin/var.cpp
+++ b/components/pango_python/src/pypangolin/var.cpp
@@ -197,7 +197,12 @@ void bind_var(pybind11::module& m){
       pybind11::arg("high") = 1.0, 
       pybind11::arg("logscale") = false, 
       pybind11::arg("toggle") = false,
-      pybind11::arg("read_only") = false);
+      pybind11::arg("read_only") = false)
+      .def_readwrite("low", &PyVarMeta::low)
+      .def_readwrite("high", &PyVarMeta::high)
+      .def_readwrite("logscale", &PyVarMeta::logscale)
+      .def_readwrite("toggle", &PyVarMeta::toggle)
+      .def_readwrite("read_only", &PyVarMeta::read_only);
 
   pybind11::class_<py_pangolin::var_t> varClass(m, "Var");
     varClass.def(pybind11::init<const std::string &>())

--- a/components/pango_python/src/pypangolin/var.hpp
+++ b/components/pango_python/src/pypangolin/var.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <optional>
 #include <pybind11/pybind11.h>
 #include <pangolin/var/var.h>
 #include <Python.h>
@@ -56,6 +57,8 @@ namespace py_pangolin {
     void set_attr_(const std::string& name, T val, const PyVarMeta & meta = {});
 
     pybind11::object gui_changed(const std::string &name);
+    bool set_meta(const std::string &name, const PyVarMeta & meta);
+    std::optional<PyVarMeta> get_meta(const std::string &name);
 
     std::vector<std::string>& get_members();     
   protected:


### PR DESCRIPTION
This PR adds GlFont and GlText to python interface and adds small improvements to python variable interface (allows changing meta information for the existing variables).