### PR TITLE
pango2: layer group bug fix and  layer group / flex layout / layout constraints code comments, refactor

### DIFF
--- a/components/pango_context/include/pangolin/context/context.h
+++ b/components/pango_context/include/pangolin/context/context.h
@@ -60,7 +60,6 @@ struct Context : std::enable_shared_from_this<Context> {
   // TODO: provide a method to serialize LayerGroup for easily
   //       saving layouts
   virtual const LayerGroup& layout() const = 0;
-  virtual LayerGroup& layout() = 0;
 
   // Specify the Layers which will make up the drawing canvas via a LayerGroup
   // object - a nested tree of Panels with a layout specification at each node.

--- a/components/pango_context/include/pangolin/gui/layer.h
+++ b/components/pango_context/include/pangolin/gui/layer.h
@@ -12,11 +12,57 @@ namespace pangolin
 
 struct Context;
 
+// Layer length unit: pixels
 struct Pixels {
   int pixels = 100;
 };
+
+// Layer length unit: ratio
 struct Parts {
   double ratio = 1.0;
+};
+
+// Unit of layer length (e.g. width, height), either in pixels or in "parts".
+using LayerLengthUnit = std::variant<Parts, Pixels>;
+
+// Layer size (width and height).
+using LayerSize = Eigen::Vector<LayerLengthUnit, 2>;
+
+struct AspectRatio {
+  AspectRatio() = default;
+
+  static AspectRatio one()
+  {
+    AspectRatio aspect;
+    aspect.setHint(1.0);
+    return aspect;
+  }
+
+  static AspectRatio fromRatio(double ratio)
+  {
+    AspectRatio aspect;
+    aspect.setHint(ratio);
+    return aspect;
+  }
+
+  bool hasHint() const { return width_by_height_hint_ != 0.0; }
+
+  double hint() const
+  {
+    PANGO_ASSERT(this->hasHint());
+    return width_by_height_hint_;
+  }
+
+  // Precondition: ratio hint must be > 0.0.
+  void setHint(double ratio_hint)
+  {
+    PANGO_ASSERT(ratio_hint >= 0.0, "got: {}", ratio_hint);
+    width_by_height_hint_ = ratio_hint;
+  }
+
+  private:
+  // precondition: width_by_height_hint_ >= 0.0
+  double width_by_height_hint_ = 0.0;  // 0.0 means we have no hint
 };
 
 ////////////////////////////////////////////////////////////////////
@@ -25,8 +71,7 @@ struct Parts {
 struct Layer : public Interactive {
   virtual ~Layer() {}
 
-  using Dim = std::variant<Parts, Pixels>;
-  using Size = Eigen::Vector<Dim, 2>;
+  using Size = LayerSize;
 
   struct RenderParams {
     Region2I region;
@@ -34,9 +79,9 @@ struct Layer : public Interactive {
 
   virtual std::string name() const = 0;
 
-  virtual Size sizeHint() const = 0;
+  virtual LayerSize sizeHint() const = 0;
 
-  virtual double aspectHint() const { return 0; };
+  virtual AspectRatio aspectHint() const { return AspectRatio{}; };
 
   virtual void renderIntoRegion(const Context&, const RenderParams&) = 0;
 
@@ -48,7 +93,7 @@ struct Layer : public Interactive {
 
   struct Params {
     std::string name = "";
-    Size size_hint = {Parts{1}, Parts{1}};
+    LayerSize size_hint = {Parts{1}, Parts{1}};
   };
   static Shared<Layer> Create(Params);
 

--- a/components/pango_context/include/pangolin/gui/layer_group.h
+++ b/components/pango_context/include/pangolin/gui/layer_group.h
@@ -13,7 +13,9 @@ namespace pangolin
 ////////////////////////////////////////////////////////////////////
 /// Represents a (possibly nested) arrangement of Panels on screen
 ///
-struct LayerGroup {
+class LayerGroup
+{
+  public:
   enum class Grouping {
     stacked,     // layers blended over one another
     tabbed,      // one layer shown at a time, with user selecting current
@@ -23,22 +25,41 @@ struct LayerGroup {
                  // available space. Requires common aspect for each layer.
   };
 
-  LayerGroup() = default;
-  LayerGroup(Shared<Layer> layer) : layer(layer) {}
-
-  Grouping grouping = Grouping::horizontal;
-  std::vector<LayerGroup> children = {};
-  std::shared_ptr<Layer> layer = nullptr;
-  size_t selected_tab = 0;
-
-  struct LayoutInfo {
-    Eigen::Array2i min_pix = {0, 0};
-    Eigen::Array2d parts = {0.0f, 0.0f};
-    double aspect_hint = 0.0;
-    Region2I region = Region2I::empty();
+  struct Params {
+    Grouping grouping = Grouping::horizontal;
+    std::shared_ptr<Layer> layer = nullptr;
+    size_t selected_tab = 0;
   };
 
-  mutable LayoutInfo cached_;
+  struct Constraints {
+    // todo: Describe semantic: What is the precise definition of min_pix?  What
+    // is the precise definition of parts?
+    Eigen::Array2i min_pix = {0, 0};
+    Eigen::Array2d parts = {0.0f, 0.0f};
+    // Hint / recommendation for what aspect ratio to use.
+    AspectRatio aspect = {};
+  };
+
+  LayerGroup() = default;
+  LayerGroup(const Params& params) : params_(params) {}
+
+  const Params& params() const { return params_; }
+
+  std::optional<Constraints>& constraints() { return constraints_; }
+  const std::optional<Constraints>& constraints() const { return constraints_; }
+
+  const std::vector<LayerGroup>& children() const { return children_; }
+  std::vector<LayerGroup>& children() { return children_; }
+
+  std::optional<Region2I>& region() { return region_; }
+  const std::optional<Region2I>& region() const { return region_; }
+
+  private:
+  std::vector<LayerGroup> children_ = {};
+
+  Params params_ = Params{};
+  std::optional<Constraints> constraints_;
+  std::optional<Region2I> region_;
 };
 
 }  // namespace pangolin

--- a/components/pango_context/src/context.cpp
+++ b/components/pango_context/src/context.cpp
@@ -25,56 +25,62 @@ void renderIntoRegionImpl(
     const Context& context, const Layer::RenderParams& p,
     const LayerGroup& group)
 {
-  if (group.layer) {
-    group.layer->renderIntoRegion(context, {.region = group.cached_.region});
+  if (group.params().layer) {
+    group.params().layer->renderIntoRegion(
+        context, {.region = PANGO_UNWRAP(group.region())});
   }
-  if (group.grouping == LayerGroup::Grouping::stacked) {
+  if (group.params().grouping == LayerGroup::Grouping::stacked) {
     // Back-to-front for blending / overlays
-    for (const auto& child : reverse(group.children)) {
+    for (const auto& child : reverse(group.children())) {
       renderIntoRegionImpl(context, p, child);
     }
-  } else if (group.grouping == LayerGroup::Grouping::tabbed) {
-    PANGO_ENSURE(group.selected_tab < group.children.size());
-    renderIntoRegionImpl(context, p, group.children[group.selected_tab]);
+  } else if (group.params().grouping == LayerGroup::Grouping::tabbed) {
+    PANGO_ENSURE(group.params().selected_tab < group.children().size());
+    renderIntoRegionImpl(
+        context, p, group.children()[group.params().selected_tab]);
   } else {
-    for (const auto& child : group.children) {
+    for (const auto& child : group.children()) {
       renderIntoRegionImpl(context, p, child);
     }
   }
 }
 
 void renderIntoRegion(
-    const Context& context, const Layer::RenderParams& p,
-    const LayerGroup& group)
+    const Context& context, const Layer::RenderParams& p, LayerGroup& mut_group)
 {
-  computeLayoutConstraints(group);
-  computeLayoutRegion(group, p.region);
+  computeLayoutConstraints(mut_group);
+  computeLayoutRegion(mut_group, p.region);
+  const LayerGroup& group = mut_group;
   renderIntoRegionImpl(context, p, group);
 }
 
 // Find layer to receive event based on pointer location
 // Return the layer which processed the event.
 //
-// Pre-condition: layer positions have been computed by a previous call to
-// render
+// Pre-condition: layer region must have been populated by a previous call to
+// render, i.e. layer_group.hasRegion() must be true.
 std::shared_ptr<Layer> giveEventToLayers(
-    const Context& context, Interactive::Event event, const LayerGroup& group)
+    const Context& context, Interactive::Event event,
+    const LayerGroup& layer_group)
 {
-  const auto r = group.cached_.region;
+  const Region2I r = PANGO_UNWRAP(layer_group.region());
   const Eigen::Vector2i winpos = event.pointer_pos.pos_window.cast<int>();
 
   if (r.contains(winpos)) {
     event.pointer_pos.region = r;
 
-    if (group.layer && group.layer->handleEvent(context, event)) {
+    if (layer_group.params().layer &&
+        layer_group.params().layer->handleEvent(context, event)) {
       // event handled, stop dfs
-      return group.layer;
+      return layer_group.params().layer;
     }
 
     // see if child nodes want it
-    for (const auto& child : group.children) {
+    for (const auto& child : layer_group.children()) {
       auto layer = giveEventToLayers(context, event, child);
-      if (layer) return layer;
+      if (layer) {
+        return layer;
+      }
     }
   }
   return nullptr;
@@ -83,21 +89,25 @@ std::shared_ptr<Layer> giveEventToLayers(
 // This is kinda dumb - we look through all nodes even though
 // we know the active_layer already. We do this just so we can
 // find the cached region so we can send it through
+//
+// Preconditions:
+//  - active_layer != nullptr
+//  - group.region() != nullopt
 bool giveEventToActiveLayer(
     const Context& context, Interactive::Event event, const LayerGroup& group,
     const std::shared_ptr<Layer>& active_layer)
 {
   PANGO_ENSURE(active_layer);
 
-  const auto r = group.cached_.region;
+  const Region2I r = PANGO_UNWRAP(group.region());
   event.pointer_pos.region = r;
 
-  if (group.layer == active_layer) {
-    group.layer->handleEvent(context, event);
+  if (group.params().layer == active_layer) {
+    group.params().layer->handleEvent(context, event);
   }
 
   // see if child nodes want it
-  for (const auto& child : group.children) {
+  for (const auto& child : group.children()) {
     const bool found =
         giveEventToActiveLayer(context, event, child, active_layer);
     if (found) return true;
@@ -343,8 +353,6 @@ struct ContextImpl : public Context {
 
   const LayerGroup& layout() const override { return layout_; }
 
-  LayerGroup& layout() override { return layout_; }
-
   ImageSize size() const override { return size_; }
 
   void drawPanels()
@@ -356,7 +364,11 @@ struct ContextImpl : public Context {
     region.extend({0, 0});
     region.extend({size_.width, size_.height});
 
-    renderIntoRegion(*this, {.region = region}, layout_);
+    renderIntoRegion(*this, {.region = region}, this->layout_);
+    PANGO_ASSERT(
+        bool(layout_.region()),
+        "Logic error: layout must have a valid region attached to it after "
+        "renderIntoRegion call.");
   }
 
   void loop(std::function<bool(void)> loop_function) override

--- a/components/pango_context/src/gl_draw_layer.cpp
+++ b/components/pango_context/src/gl_draw_layer.cpp
@@ -299,22 +299,24 @@ struct DrawLayerImpl : public DrawLayer {
 
   Size sizeHint() const override { return size_hint_; }
 
-  double aspectHint() const override
+  AspectRatio aspectHint() const override
   {
     Region3F64 cam_bounds = Region3F64::empty();
     for (const auto& obj : pixels_collection_.drawables) {
       cam_bounds.extend(obj->boundsInParent());
     }
-    if (!cam_bounds.isEmpty()) {
+    if (cam_bounds.isProper()) {
+      // cam_bounds are not empty nor degenerated
       Eigen::Vector2d dim = cam_bounds.range().head<2>();
-      return dim.x() / dim.y();
+      return AspectRatio::fromRatio(dim.x() / dim.y());
     }
-    if (render_state_.camera.imageSize().width &&
-        render_state_.camera.imageSize().height) {
-      return (double)render_state_.camera.imageSize().width /
-             (double)render_state_.camera.imageSize().height;
+    if (render_state_.camera.imageSize().width > 0 &&
+        render_state_.camera.imageSize().height > 0) {
+      return AspectRatio::fromRatio(
+          (double)render_state_.camera.imageSize().width /
+          (double)render_state_.camera.imageSize().height);
     }
-    return 1.0;
+    return AspectRatio::one();
   };
 
   void add(

--- a/components/pango_context/src/layer_group_test.cpp
+++ b/components/pango_context/src/layer_group_test.cpp
@@ -1,1 +1,14 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pangolin/gui/all_layers.h>
 #include <pangolin/gui/layer_group.h>
+
+namespace pangolin
+{
+
+TEST_CASE("computeLayoutConstraints, smoke")
+{
+  Shared<DrawLayer> default_draw_layer = pangolin::DrawLayer::Create({});
+  LayerGroup group = makeLayerGroup(default_draw_layer);
+  computeLayoutConstraints(group);
+}
+}  // namespace pangolin

--- a/components/pango_core/include/pangolin/utils/logging.h
+++ b/components/pango_core/include/pangolin/utils/logging.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <farm_ng/core/logging/logger.h>
 #include <fmt/format.h>
 #include <pangolin/utils/fmt.h>
 
@@ -100,6 +101,8 @@
         "We've reached code we thought was unreachable.");                     \
     ::std::abort();                                                            \
   } while (false)
+
+#define PANGO_UNWRAP(expr, ...) FARM_UNWRAP(expr, ##__VA_ARGS__)
 
 namespace pangolin
 {


### PR DESCRIPTION
 - layout bug fixes (devide by zero aspect hints => fallback to 1.0 ratio)
 - minimal test case / smoke test for ``computeLayoutConstraints``
 - minor refactor and comments for LayoutGroup and corresponding functions
   * separate LayerGroup into constants params struct + constraints struct (first layout path) + region (result of second layout pass)
   * some encapsulation of AspectRatio hint to catch NAN / devided by zero and other improper ratios systematically