### PR TITLE
Support shader reload

### DIFF
--- a/components/pango_context/src/gl_drawable/gl_drawn_checker.cpp
+++ b/components/pango_context/src/gl_drawable/gl_drawn_checker.cpp
@@ -33,14 +33,14 @@ struct GlDrawnChecker : public DrawnChecker {
   }
 
   private:
-  const Shared<GlSlProgram> prog = GlSlProgram::Create(
+  Shared<GlSlProgram> prog = GlSlProgram::Create(
       {.sources = {
            {.origin = "/components/pango_opengl/shaders/main_checker.glsl"}}});
   GlVertexArrayObject vao = {};
-  const GlUniform<Eigen::Vector2f> u_viewport_size = {"viewport_size"};
-  const GlUniform<Eigen::Vector4f> u_color1 = {"color1"};
-  const GlUniform<Eigen::Vector4f> u_color2 = {"color2"};
-  const GlUniform<int> u_checksize = {"checksize"};
+  GlUniform<Eigen::Vector2f> u_viewport_size = {prog, "viewport_size"};
+  GlUniform<Eigen::Vector4f> u_color1 = {prog, "color1"};
+  GlUniform<Eigen::Vector4f> u_color2 = {prog, "color2"};
+  GlUniform<int> u_checksize = {prog, "checksize"};
 };
 
 Shared<DrawnChecker> DrawnChecker::Create(DrawnChecker::Params p)

--- a/components/pango_context/src/gl_drawable/gl_drawn_image.cpp
+++ b/components/pango_context/src/gl_drawable/gl_drawn_image.cpp
@@ -59,16 +59,16 @@ struct GlDrawnImage : public DrawnImage {
   }
 
   private:
-  const Shared<GlSlProgram> prog = GlSlProgram::Create(
+  Shared<GlSlProgram> prog = GlSlProgram::Create(
       {.sources = {
            {.origin = "/components/pango_opengl/shaders/main_image.glsl"}}});
   GlVertexArrayObject vao = {};
-  const GlUniform<int> texture_unit = {"image"};
-  const GlUniform<Eigen::Matrix4f> u_intrinsics = {"proj"};
-  const GlUniform<Eigen::Matrix4f> u_cam_from_drawable = {"cam_from_world"};
-  const GlUniform<Eigen::Vector2f> u_image_size = {"image_size"};
-  const GlUniform<Eigen::Matrix4f> u_color_transform = {"color_transform"};
-  const GlUniform<Palette> u_colormap_index = {"colormap_index"};
+  GlUniform<int> texture_unit = {prog, "image"};
+  GlUniform<Eigen::Matrix4f> u_intrinsics = {prog, "proj"};
+  GlUniform<Eigen::Matrix4f> u_cam_from_drawable = {prog, "cam_from_world"};
+  GlUniform<Eigen::Vector2f> u_image_size = {prog, "image_size"};
+  GlUniform<Eigen::Matrix4f> u_color_transform = {prog, "color_transform"};
+  GlUniform<Palette> u_colormap_index = {prog, "colormap_index"};
 };
 
 Shared<DrawnImage> DrawnImage::Create(DrawnImage::Params p)

--- a/components/pango_context/src/gl_drawable/gl_drawn_plot_background.cpp
+++ b/components/pango_context/src/gl_drawable/gl_drawn_plot_background.cpp
@@ -70,22 +70,22 @@ struct GlDrawnPlotBackground : public DrawnPlotBackground {
   }
 
   private:
-  const Shared<GlSlProgram> prog = GlSlProgram::Create(
+  Shared<GlSlProgram> prog = GlSlProgram::Create(
       {.sources = {
            {.origin = "/components/pango_opengl/shaders/"
                       "main_plot_background.glsl"}}});
   GlVertexArrayObject vao = {};
-  const GlUniform<Eigen::Matrix4f> u_graph_from_clip = {"graph_from_clip"};
-  const GlUniform<Eigen::Vector4f> u_color_background = {"color_background"};
-  const GlUniform<Eigen::Vector4f> u_tick_color_scale = {"tick_color_scale"};
-  const GlUniform<Eigen::Vector2f> u_graph_units_per_pixel = {
-      "graph_units_per_pixel"};
-  const GlUniform<Eigen::Vector2f> u_log_s_min_dist = {"log_s_min_dist"};
-  const GlUniform<Eigen::Vector2f> u_log_s_of_octave_start = {
-      "log_s_of_octave_start"};
-  const GlUniform<Eigen::Vector2f> u_octave_start = {"octave_start"};
+  GlUniform<Eigen::Matrix4f> u_graph_from_clip = {prog, "graph_from_clip"};
+  GlUniform<Eigen::Vector4f> u_color_background = {prog, "color_background"};
+  GlUniform<Eigen::Vector4f> u_tick_color_scale = {prog, "tick_color_scale"};
+  GlUniform<Eigen::Vector2f> u_graph_units_per_pixel = {
+      prog, "graph_units_per_pixel"};
+  GlUniform<Eigen::Vector2f> u_log_s_min_dist = {prog, "log_s_min_dist"};
+  GlUniform<Eigen::Vector2f> u_log_s_of_octave_start = {
+      prog, "log_s_of_octave_start"};
+  GlUniform<Eigen::Vector2f> u_octave_start = {prog, "octave_start"};
 
-  const GlUniform<float> u_num_divisions = {"num_divisions"};
+  GlUniform<float> u_num_divisions = {prog, "num_divisions"};
 };
 
 Shared<DrawnPlotBackground> DrawnPlotBackground::Create(

--- a/components/pango_context/src/gl_drawable/gl_drawn_solids.cpp
+++ b/components/pango_context/src/gl_drawable/gl_drawn_solids.cpp
@@ -37,14 +37,14 @@ struct GlDrawnSolids : public DrawnSolids {
   }
 
   private:
-  const Shared<GlSlProgram> prog = GlSlProgram::Create(
+  Shared<GlSlProgram> prog = GlSlProgram::Create(
       {.sources = {
            {.origin = "/components/pango_opengl/shaders/main_plane.glsl"}}});
   GlVertexArrayObject vao = {};
-  const GlUniform<Eigen::Matrix4f> u_cam_from_clip = {"camera_from_clip"};
-  const GlUniform<Eigen::Matrix4f> u_world_from_drawable = {"world_from_cam"};
-  const GlUniform<Eigen::Vector2f> u_znear_zfar = {"znear_zfar"};
-  const GlUniform<bool> u_use_unproject_map = {"use_unproject_map"};
+  GlUniform<Eigen::Matrix4f> u_cam_from_clip{prog, "camera_from_clip"};
+  GlUniform<Eigen::Matrix4f> u_world_from_drawable{prog, "world_from_cam"};
+  GlUniform<Eigen::Vector2f> u_znear_zfar{prog, "znear_zfar"};
+  GlUniform<bool> u_use_unproject_map{prog, "use_unproject_map"};
 };
 
 Shared<DrawnSolids> DrawnSolids::Create(DrawnSolids::Params p)

--- a/components/pango_context/src/gl_drawable/gl_drawn_text.cpp
+++ b/components/pango_context/src/gl_drawable/gl_drawn_text.cpp
@@ -153,16 +153,17 @@ struct GlDrawnText : public DrawnText {
     return sophus::Region3F64::empty();
   }
 
-  const Shared<GlSlProgram> prog = GlSlProgram::Create(
+  Shared<GlSlProgram> prog = GlSlProgram::Create(
       {.sources = {
            {.origin = "/components/pango_opengl/shaders/main_text.glsl"}}});
-  GlUniform<int> u_font_atlas = {"u_font_atlas"};
-  GlUniform<int> u_font_offsets = {"u_font_offsets"};
-  GlUniform<Eigen::Array3f> u_color = {"u_color"};
+  GlUniform<int> u_font_atlas = {prog, "u_font_atlas"};
+  GlUniform<int> u_font_offsets = {prog, "u_font_offsets"};
+  GlUniform<Eigen::Array3f> u_color = {prog, "u_color"};
 
-  GlUniform<int> u_font_bitmap_type = {"u_font_bitmap_type"};
-  GlUniform<Eigen::Array2f> u_max_sdf_dist_uv = {"u_max_sdf_dist_uv"};
-  GlUniform<Eigen::Matrix4f> u_clip_from_fontpix = {"u_clip_from_fontpix"};
+  GlUniform<int> u_font_bitmap_type = {prog, "u_font_bitmap_type"};
+  GlUniform<Eigen::Array2f> u_max_sdf_dist_uv = {prog, "u_max_sdf_dist_uv"};
+  GlUniform<Eigen::Matrix4f> u_clip_from_fontpix = {
+      prog, "u_clip_from_fontpix"};
 
   std::shared_ptr<GlFont> font;
   GlTexture font_offsets;

--- a/components/pango_context/src/gl_layer/gl_widget_layer.h
+++ b/components/pango_context/src/gl_layer/gl_widget_layer.h
@@ -93,27 +93,28 @@ struct GlWidgetLayer : WidgetLayer {
       color_slider_outline = {0.8f, 0.6f, 0.6f};
     }
 
-    const Shared<GlSlProgram> prog = GlSlProgram::Create(
+    Shared<GlSlProgram> prog = GlSlProgram::Create(
         {.sources = {
              {.origin =
                   "/components/pango_opengl/shaders/main_widgets.glsl"}}});
-    GlUniform<float> width = {"u_width"};
-    GlUniform<float> height = {"u_height"};
-    GlUniform<float> padding = {"u_padding"};
-    GlUniform<int> num_widgets = {"u_num_widgets"};
-    GlUniform<int> selected_index = {"u_selected_index"};
+    GlUniform<float> width{prog, "u_width"};
+    GlUniform<float> height{prog, "u_height"};
+    GlUniform<float> padding{prog, "u_padding"};
+    GlUniform<int> num_widgets{prog, "u_num_widgets"};
+    GlUniform<int> selected_index{prog, "u_selected_index"};
 
-    GlUniform<float> slider_outline_border = {"slider_outline_border"};
-    GlUniform<float> boss_border = {"boss_border"};
-    GlUniform<float> boss_radius_factor = {"boss_radius_factor"};
+    GlUniform<float> slider_outline_border{prog, "slider_outline_border"};
+    GlUniform<float> boss_border{prog, "boss_border"};
+    GlUniform<float> boss_radius_factor{prog, "boss_radius_factor"};
 
-    GlUniform<Eigen::Array3f> color_panel = {"color_panel"};
-    GlUniform<Eigen::Array3f> color_boss_base = {"color_boss_base"};
-    GlUniform<Eigen::Array3f> color_boss_diff = {"color_boss_diff"};
-    GlUniform<Eigen::Array3f> color_slider = {"color_slider"};
-    GlUniform<Eigen::Array3f> color_slider_outline = {"color_slider_outline"};
+    GlUniform<Eigen::Array3f> color_panel{prog, "color_panel"};
+    GlUniform<Eigen::Array3f> color_boss_base{prog, "color_boss_base"};
+    GlUniform<Eigen::Array3f> color_boss_diff{prog, "color_boss_diff"};
+    GlUniform<Eigen::Array3f> color_slider{prog, "color_slider"};
+    GlUniform<Eigen::Array3f> color_slider_outline{
+        prog, "color_slider_outline"};
 
-    GlUniform<Eigen::Matrix4f> clip_from_pix = {"u_T_cm"};
+    GlUniform<Eigen::Matrix4f> clip_from_pix{prog, "u_T_cm"};
 
     pangolin::GlBuffer vbo;
     GlVertexArrayObject vao = {};
@@ -128,17 +129,17 @@ struct GlWidgetLayer : WidgetLayer {
       color = {0.0f, 0.0f, 0.0f};
     }
 
-    const Shared<GlSlProgram> prog = GlSlProgram::Create(
+    Shared<GlSlProgram> prog = GlSlProgram::Create(
         {.sources = {
              {.origin = "/components/pango_opengl/shaders/main_text.glsl"}}});
-    GlUniform<int> font_atlas = {"u_font_atlas"};
-    GlUniform<int> font_offsets = {"u_font_offsets"};
-    GlUniform<Eigen::Array3f> color = {"u_color"};
+    GlUniform<int> font_atlas{prog, "u_font_atlas"};
+    GlUniform<int> font_offsets{prog, "u_font_offsets"};
+    GlUniform<Eigen::Array3f> color{prog, "u_color"};
 
-    GlUniform<int> font_bitmap_type = {"u_font_bitmap_type"};
-    GlUniform<Eigen::Array2f> max_sdf_dist_uv = {"u_max_sdf_dist_uv"};
+    GlUniform<int> font_bitmap_type{prog, "u_font_bitmap_type"};
+    GlUniform<Eigen::Array2f> max_sdf_dist_uv{prog, "u_max_sdf_dist_uv"};
 
-    GlUniform<Eigen::Matrix4f> clip_from_pix = {"u_clip_from_fontpix"};
+    GlUniform<Eigen::Matrix4f> clip_from_pix{prog, "u_clip_from_fontpix"};
 
     pangolin::GlBuffer vbo_pos;
     pangolin::GlBuffer vbo_index;

--- a/components/pango_opengl/include/pangolin/gl/glsl_program.h
+++ b/components/pango_opengl/include/pangolin/gl/glsl_program.h
@@ -27,9 +27,9 @@
 
 #pragma once
 
-#include <pangolin/gl/uniform.h>
 #include <pangolin/utils/scoped_bind.h>
 #include <pangolin/utils/shared.h>
+#include <sigslot/signal.hpp>
 
 #include <filesystem>
 #include <map>
@@ -74,22 +74,27 @@ struct GlSlProgram {
 
   virtual ~GlSlProgram() {}
 
-  virtual ScopedBind<GlSlProgram> bind() const = 0;
+  virtual ScopedBind<GlSlProgram> bind() = 0;
 
-  virtual Attributes getAttributes() const = 0;
+  virtual Attributes getAttributes() = 0;
 
-  virtual Uniforms getUniforms() const = 0;
+  virtual Uniforms getUniforms() = 0;
 
-  virtual void reload() = 0;
+  enum class Event { program_unlinked };
+  virtual sigslot::signal<Event>& signalEvent() = 0;
 
   struct Params {
     std::vector<Source> sources;
     Defines program_defines = {};
     PathList search_path = {};
-    bool link_immediately = true;
+    bool link_immediately = false;
     bool automatically_reload = true;
   };
-  static Shared<GlSlProgram> Create(Params p);
+  static Shared<GlSlProgram> Create(const Params& p);
+
+  virtual void reload() = 0;
+
+  virtual void reload(const Params& new_params) = 0;
 };
 
 }  // namespace pangolin

--- a/components/pango_opengl/src/glsl_preprocessor.cpp
+++ b/components/pango_opengl/src/glsl_preprocessor.cpp
@@ -1,5 +1,7 @@
+#include <fmt/color.h>
 #include <fmt/ranges.h>
 #include <pangolin/gl/glsl_preprocessor.h>
+#include <pangolin/utils/logging.h>
 #include <pangolin/utils/string.h>
 
 #include <fstream>

--- a/examples/15.reload-example.cpp
+++ b/examples/15.reload-example.cpp
@@ -1,0 +1,70 @@
+#include <pangolin/context/context.h>
+#include <pangolin/gl/gl_vao.h>
+#include <pangolin/gl/glsl_program.h>
+#include <pangolin/gl/uniform.h>
+#include <pangolin/layer/all_layers.h>
+#include <pangolin/video/video.h>
+
+/*
+  == Pangolin-by-example ==
+
+*/
+
+using namespace pangolin;
+using namespace sophus;
+
+// Forward declaration. See end of this file for the inline shader code.
+extern const char* eg_shader;
+
+struct ExampleCustomLayer : public Layer {
+  ExampleCustomLayer(const std::filesystem::path& shader_path)
+  {
+    prog->reload({.sources = {{.origin = shader_path}}});
+  }
+
+  std::string name() const override { return "example"; }
+
+  Size sizeHint() const override { return size_; }
+
+  void renderIntoRegion(const Context& c, const RenderParams& p) override
+  {
+    c.setViewport(p.region);
+    auto bind_prog = prog->bind();
+    auto bind_vao = vao.bind();
+    u_time = std::fmod(u_time.getValue() + 0.01, 1.0);
+    PANGO_GL(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
+  }
+
+  bool handleEvent(const Context&, const Event& e) override
+  {
+    if (std::holds_alternative<KeyboardEvent>(e.detail)) {
+      prog->reload();
+      return true;
+    }
+    return false;
+  }
+
+  GlVertexArrayObject vao = {};
+  Shared<GlSlProgram> prog = GlSlProgram::Create({});
+  GlUniform<float> u_time = {prog, "time"};
+  Size size_ = {Parts{1}, Parts{1}};
+};
+
+int main(int argc, char** argv)
+{
+  PANGO_ENSURE(
+      argc == 2,
+      "Please provide one argument - the path to a full-screen shader.");
+  const std::filesystem::path shader_path = argv[1];
+
+  auto context = Context::Create({
+      .title = "Pangolin Shader Reload",
+      .window_size = {640, 480},
+  });
+
+  auto custom = Shared<ExampleCustomLayer>::make(shader_path);
+  context->setLayout(custom);
+
+  context->loop();
+  return 0;
+}

--- a/examples/6.overlay.cpp
+++ b/examples/6.overlay.cpp
@@ -1,6 +1,7 @@
 #include <pangolin/context/context.h>
 #include <pangolin/gl/gl_vao.h>
 #include <pangolin/gl/glsl_program.h>
+#include <pangolin/gl/uniform.h>
 #include <pangolin/layer/all_layers.h>
 #include <pangolin/video/video.h>
 
@@ -30,9 +31,9 @@ struct ExampleCustomLayer : public Layer {
   }
 
   GlVertexArrayObject vao = {};
-  const Shared<GlSlProgram> prog =
+  Shared<GlSlProgram> prog =
       GlSlProgram::Create({.sources = {{.glsl_code = eg_shader}}});
-  GlUniform<float> u_time = {"time"};
+  GlUniform<float> u_time = {prog, "time"};
   Size size_ = {Parts{1}, Parts{1}};
 };
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,6 +17,7 @@ set(examples
     12.named_drawables
     13.plot-experiment
     14.mesh-loading
+    15.reload-example
 )
 
 foreach(example IN LISTS examples)


### PR DESCRIPTION
`GLUniform`s must now be associated with a `GlSlProgram`. 

The `GlSlProgram` will signal associated uniforms when it has been unlinked, so that uniforms can reinitialize themselves.