### PR TITLE
Fix Icosphere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       with:
         path: ${{runner.workspace}}/Pangolin/Sophus
         repository: 'strasdat/Sophus'
-        ref: 5cb40f05e84ab5b8cc05ff1e1ae080bc9b61bed2
+        ref: a4070695b4bca492647a7966e4cb50f90a44ec95
 
     - name: Checkout Pangolin
       uses: actions/checkout@v2

--- a/components/pango_context/src/context.cpp
+++ b/components/pango_context/src/context.cpp
@@ -430,7 +430,8 @@ struct ContextImpl : public Context {
     const auto maybe_gl_pixel_type = glTypeInfo(pixel_type);
     const GlFormatInfo gl_pixel_type = SOPHUS_UNWRAP(maybe_gl_pixel_type);
 
-    IntensityImage<> image(ImageSize(imsize[0], imsize[1]), pixel_type);
+    auto image = IntensityImage<>::fromFormat(
+        ImageSize(imsize[0], imsize[1]), pixel_type);
 
     glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
     glDrawBuffer(GL_FRONT);

--- a/components/pango_context/src/gl_drawable/gl_drawn_image.cpp
+++ b/components/pango_context/src/gl_drawable/gl_drawn_image.cpp
@@ -35,7 +35,7 @@ struct GlDrawnImage : public DrawnImage {
     if (color_transform) {
       u_color_transform = color_transform->cast<float>();
     } else if (
-        image->pixelFormat().num_channels == 1 &&
+        image->pixelFormat().num_components == 1 &&
         u_colormap_index.getValue() == Palette::none) {
       u_color_transform =
           (Eigen::Matrix4f() << 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1)

--- a/components/pango_context/src/gl_drawable/gl_drawn_primitives.cpp
+++ b/components/pango_context/src/gl_drawable/gl_drawn_primitives.cpp
@@ -201,7 +201,7 @@ struct GlDrawnPrimitives : public DrawnPrimitives {
 
       for (int i = 0; i < 4; ++i) {
         vao.addVertexAttrib(
-            location_vertex + i, *vertices, i * data_type.bytesPerPixel());
+            location_vertex + i, *vertices, i * data_type.numBytesPerPixel());
       }
 
       PANGO_GL(glDrawArrays(GL_POINTS, 0, vertices->size() - 3));

--- a/components/pango_context/src/make_drawable.cpp
+++ b/components/pango_context/src/make_drawable.cpp
@@ -143,8 +143,7 @@ Shared<Drawable> DrawableConversionTraits<draw::Icosphere>::makeDrawable(
   auto prims = DrawnPrimitives::Create({
       .element_type = DrawnPrimitives::Type::triangles,
   });
-  using FaceT = Eigen::Matrix<uint32_t, 3, 1>;
-  std::vector<FaceT> faces;
+  std::vector<uint32_t> faces;
 
   // http://www.songho.ca/opengl/gl_sphere.html#icosphere
   static float constexpr kHAngle = M_PI / 180 * 72;
@@ -173,57 +172,59 @@ Shared<Drawable> DrawableConversionTraits<draw::Icosphere>::makeDrawable(
 
   vertices.push_back({0, 0, -sphere.radius});
 
-  faces.push_back(FaceT(0, 1, 3));
-  faces.push_back(FaceT(0, 3, 5));
-  faces.push_back(FaceT(0, 5, 7));
-  faces.push_back(FaceT(0, 7, 9));
-  faces.push_back(FaceT(0, 9, 1));
-
-  faces.push_back(FaceT(11, 4, 2));
-  faces.push_back(FaceT(11, 6, 4));
-  faces.push_back(FaceT(11, 8, 6));
-  faces.push_back(FaceT(11, 10, 8));
-  faces.push_back(FaceT(11, 2, 10));
-
-  faces.push_back(FaceT(1, 2, 3));
-  faces.push_back(FaceT(2, 4, 3));
-  faces.push_back(FaceT(3, 4, 5));
-  faces.push_back(FaceT(4, 6, 5));
-  faces.push_back(FaceT(5, 6, 7));
-  faces.push_back(FaceT(6, 8, 7));
-  faces.push_back(FaceT(7, 8, 9));
-  faces.push_back(FaceT(8, 10, 9));
-  faces.push_back(FaceT(9, 10, 1));
-  faces.push_back(FaceT(10, 2, 1));
+  faces.insert(faces.end(), {0, 1, 3});
+  faces.insert(faces.end(), {0, 3, 5});
+  faces.insert(faces.end(), {0, 5, 7});
+  faces.insert(faces.end(), {0, 7, 9});
+  faces.insert(faces.end(), {0, 9, 1});
+  faces.insert(faces.end(), {11, 4, 2});
+  faces.insert(faces.end(), {11, 6, 4});
+  faces.insert(faces.end(), {11, 8, 6});
+  faces.insert(faces.end(), {11, 10, 8});
+  faces.insert(faces.end(), {11, 2, 10});
+  faces.insert(faces.end(), {1, 2, 3});
+  faces.insert(faces.end(), {2, 4, 3});
+  faces.insert(faces.end(), {3, 4, 5});
+  faces.insert(faces.end(), {4, 6, 5});
+  faces.insert(faces.end(), {5, 6, 7});
+  faces.insert(faces.end(), {6, 8, 7});
+  faces.insert(faces.end(), {7, 8, 9});
+  faces.insert(faces.end(), {8, 10, 9});
+  faces.insert(faces.end(), {9, 10, 1});
+  faces.insert(faces.end(), {10, 2, 1});
 
   for (size_t i = 0; i < sphere.num_subdivisions; ++i) {
-    std::vector<FaceT> source_faces = faces;
+    std::vector<uint32_t> source_faces = faces;
     faces.clear();
-    for (const FaceT& t : source_faces) {
+    for (size_t j = 0; j < source_faces.size(); j += 3) {
+      auto t0 = source_faces[j];
+      auto t1 = source_faces[j + 1];
+      auto t2 = source_faces[j + 2];
       Eigen::Vector3f p0_p1 =
-          (vertices[t.x()] + vertices[t.y()]).normalized() * sphere.radius;
-      int p0_p1_id = vertices.size();
+          (vertices[t0] + vertices[t1]).normalized() * sphere.radius;
+      uint32_t p0_p1_id = vertices.size();
       vertices.push_back(p0_p1);
 
       Eigen::Vector3f p0_p2 =
-          (vertices[t.x()] + vertices[t.z()]).normalized() * sphere.radius;
-      int p0_p2_id = vertices.size();
+          (vertices[t0] + vertices[t2]).normalized() * sphere.radius;
+      uint32_t p0_p2_id = vertices.size();
       vertices.push_back(p0_p2);
 
       Eigen::Vector3f p1_p2 =
-          (vertices[t.y()] + vertices[t.z()]).normalized() * sphere.radius;
-      int p1_p2_id = vertices.size();
+          (vertices[t1] + vertices[t2]).normalized() * sphere.radius;
+      uint32_t p1_p2_id = vertices.size();
       vertices.push_back(p1_p2);
 
-      faces.push_back(FaceT(t.x(), p0_p1_id, p0_p2_id));
-      faces.push_back(FaceT(t.y(), p1_p2_id, p0_p1_id));
-      faces.push_back(FaceT(t.z(), p0_p2_id, p1_p2_id));
-      faces.push_back(FaceT(p0_p1_id, p1_p2_id, p0_p2_id));
+      faces.insert(faces.end(), {t0, p0_p1_id, p0_p2_id});
+      faces.insert(faces.end(), {t1, p1_p2_id, p0_p1_id});
+      faces.insert(faces.end(), {t2, p0_p2_id, p1_p2_id});
+      faces.insert(faces.end(), {p0_p1_id, p1_p2_id, p0_p2_id});
     }
   }
 
   prims->vertices->queueUpdate(std::move(vertices));
   prims->indices->queueUpdate(std::move(faces));
+  prims->default_color = sphere.color;
 
   return prims;
 }

--- a/components/pango_image/src/image_io_jpg.cpp
+++ b/components/pango_image/src/image_io_jpg.cpp
@@ -191,7 +191,7 @@ IntensityImage<> LoadJpg(std::istream& is)
     // resize storage if necessary
     PixelFormat fmt =
         PixelFormatFromString(cinfo.output_components == 3 ? "RGB24" : "GRAY8");
-    image = sophus::IntensityImage<>(
+    image = sophus::IntensityImage<>::fromFormat(
         ImageSize(cinfo.output_width, cinfo.output_height), fmt);
     JSAMPARRAY imageBuffer = (*cinfo.mem->alloc_sarray)(
         (j_common_ptr)&cinfo, JPOOL_IMAGE,
@@ -289,7 +289,7 @@ void SaveJpg(const IntensityImage<>& img, std::ostream& os, float quality)
   if (img.numChannels() != 1 && img.numChannels() != 3) {
     throw std::runtime_error("Unsupported number of image channels.");
   }
-  if (img.numBytesPerPixelChannel() != 1) {
+  if (img.pixelFormat().num_bytes_per_component != 1) {
     throw std::runtime_error("Unsupported image depth.");
   }
 

--- a/components/pango_image/src/image_io_lz4.cpp
+++ b/components/pango_image/src/image_io_lz4.cpp
@@ -80,8 +80,9 @@ IntensityImage<> LoadLz4(std::istream& in)
   lz4_image_header header;
   in.read((char*)&header, sizeof(header));
 
-  IntensityImage<> img(
+  auto img = IntensityImage<>::fromFormat(
       ImageSize(header.w, header.h), PixelFormatFromString(header.fmt));
+
   std::unique_ptr<char[]> input_buffer(new char[header.compressed_size]);
 
   in.read(input_buffer.get(), header.compressed_size);

--- a/components/pango_image/src/image_io_packed12bit.cpp
+++ b/components/pango_image/src/image_io_packed12bit.cpp
@@ -19,7 +19,7 @@ struct packed12bit_image_header {
 
 void SavePacked12bit(const IntensityImage<>& image, std::ostream& out)
 {
-  if (image.numBytesPerPixelChannel() != 2) {
+  if (image.pixelFormat().num_bytes_per_component != 2) {
     throw std::runtime_error(
         "packed12bit currently only supported with 16bit input image");
   }
@@ -62,10 +62,10 @@ IntensityImage<> LoadPacked12bit(std::istream& in)
   packed12bit_image_header header;
   in.read((char*)&header, sizeof(header));
 
-  IntensityImage<> img(
+  auto img = IntensityImage<>::fromFormat(
       sophus::ImageSize(header.w, header.h), PixelFormatFromString(header.fmt));
 
-  if (img.numBytesPerPixelChannel() != 2) {
+  if (img.pixelFormat().num_bytes_per_component != 2) {
     throw std::runtime_error(
         "packed12bit currently only supported with 16bit input image");
   }

--- a/components/pango_image/src/image_io_png.cpp
+++ b/components/pango_image/src/image_io_png.cpp
@@ -136,7 +136,7 @@ IntensityImage<> LoadPng(std::istream& source)
 
   auto shape = sophus::ImageLayout::makeFromSizeAndPitch<uint8_t>(
       sophus::ImageSize(w, h), pitch);
-  IntensityImage<> img(shape, PngFormat(png_ptr, info_ptr));
+  auto img = IntensityImage<>::fromFormat(shape, PngFormat(png_ptr, info_ptr));
 
   png_bytepp rows = png_get_rows(png_ptr, info_ptr);
   for (unsigned int r = 0; r < h; r++) {
@@ -191,7 +191,7 @@ void SavePng(
       png_ptr, (png_voidp)&stream, pango_png_stream_write,
       pango_png_stream_write_flush);
 
-  const int bit_depth = image.numBytesPerPixelChannel() * 8;
+  const int bit_depth = image.pixelFormat().num_bytes_per_component * 8;
 
   int colour_type;
   switch (image.numChannels()) {

--- a/components/pango_image/src/image_io_ppm.cpp
+++ b/components/pango_image/src/image_io_ppm.cpp
@@ -48,7 +48,7 @@ IntensityImage<> LoadPpm(std::istream& in)
   in.ignore(1, '\n');
 
   if (!in.fail() && w > 0 && h > 0) {
-    IntensityImage<> img(
+    auto img = IntensityImage<>::fromFormat(
         sophus::ImageSize(w, h), PpmFormat(ppm_type, num_colors));
 
     // Read in data

--- a/components/pango_image/src/image_io_raw.cpp
+++ b/components/pango_image/src/image_io_raw.cpp
@@ -14,7 +14,7 @@ IntensityImage<> LoadImageNonPlanar(
 {
   ImageLayout shape = ImageLayout::makeFromSizeAndPitch<uint8_t>(
       ImageSize(raw_width, raw_height), raw_pitch);
-  IntensityImage<> img(shape, raw_fmt);
+  auto img = IntensityImage<>::fromFormat(shape, raw_fmt);
 
   // Read from file, row at a time.
   std::ifstream bFile(filename.c_str(), std::ios::in | std::ios::binary);
@@ -33,11 +33,11 @@ template <typename Tin, typename Tout>
 IntensityImage<> ToNonPlanarT(const IntensityImageView& planar_image)
 {
   PixelFormat new_fmt = PixelFormat::fromTemplate<Tout>();
-  const size_t planes = new_fmt.num_channels;
+  const size_t planes = new_fmt.num_components;
 
   PANGO_ENSURE(planar_image.height() % planes == 0);
   PANGO_ENSURE(sizeof(Tin) * planes == sizeof(Tout));
-  PANGO_ENSURE(sizeof(Tout) == new_fmt.bytesPerPixel());
+  PANGO_ENSURE(sizeof(Tout) == new_fmt.numBytesPerPixel());
 
   ImageView<Tin> in = planar_image.imageView<Tin>();
   MutImage<Tout> out(

--- a/components/pango_image/src/image_io_tga.cpp
+++ b/components/pango_image/src/image_io_tga.cpp
@@ -40,7 +40,7 @@ IntensityImage<> LoadTga(std::istream& in)
   const int height = info[2] + (info[3] * 256);
 
   if (in.good()) {
-    IntensityImage<> img(
+    auto img = IntensityImage<>::fromFormat(
         sophus::ImageSize(width, height), TgaFormat(info[4], type[2], type[1]));
 
     // read in image data

--- a/components/pango_image/src/image_io_tiff.cpp
+++ b/components/pango_image/src/image_io_tiff.cpp
@@ -80,7 +80,7 @@ IntensityImage<> LoadTiff(const std::string& filename)
           "image_io_tiff.cpp.");
   }
 
-  IntensityImage<> image(
+  auto image = IntensityImage<>::fromFormat(
       sophus::ImageSize(width, height), PixelFormatFromString(sfmt.c_str()));
   const tsize_t scanlength_bytes = TIFFScanlineSize(tif);
   if (scanlength_bytes != tsize_t(image.pitchBytes()))

--- a/components/pango_image/src/image_io_zstd.cpp
+++ b/components/pango_image/src/image_io_zstd.cpp
@@ -57,8 +57,9 @@ void SaveZstd(
       ZSTD_isError(initResult), "ZSTD_initCStream() error : {}",
       ZSTD_getErrorName(initResult));
 
-  const size_t row_size_bytes =
-      image.numChannels() * image.numBytesPerPixelChannel() * image.width();
+  const size_t row_size_bytes = image.numChannels() *
+                                image.pixelFormat().num_bytes_per_component *
+                                image.width();
 
   for (int y = 0; y < image.height(); ++y) {
     ZSTD_inBuffer input = {image.rawRowPtr(y), row_size_bytes, 0};
@@ -98,7 +99,7 @@ IntensityImage<> LoadZstd(std::istream& in)
   zstd_image_header header;
   in.read((char*)&header, sizeof(header));
 
-  IntensityImage<> img(
+  auto img = IntensityImage<>::fromFormat(
       ImageSize(header.w, header.h), PixelFormatFromString(header.fmt));
 
   const size_t input_buffer_size = ZSTD_DStreamInSize();

--- a/components/pango_opengl/include/pangolin/gl/gl.hpp
+++ b/components/pango_opengl/include/pangolin/gl/gl.hpp
@@ -256,67 +256,82 @@ inline void GlTexture::Download(sophus::IntensityImage<>& image) const
 
   switch (internal_format) {
     case GL_LUMINANCE8:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("GRAY8"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("GRAY8"));
       Download(unsafe_ptr, GL_RED, GL_UNSIGNED_BYTE);
       break;
     case GL_LUMINANCE16:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("GRAY16LE"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("GRAY16LE"));
       Download(unsafe_ptr, GL_RED, GL_UNSIGNED_SHORT);
       break;
     case GL_RGB8:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("RGB24"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("RGB24"));
       Download(unsafe_ptr, GL_RGB, GL_UNSIGNED_BYTE);
       break;
     case GL_RGBA8:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("RGBA32"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("RGBA32"));
       Download(unsafe_ptr, GL_RGBA, GL_UNSIGNED_BYTE);
       break;
     case GL_RED_INTEGER:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("GRAY32"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("GRAY32"));
       Download(unsafe_ptr, GL_RED, GL_UNSIGNED_INT);
       break;
     case GL_LUMINANCE:
     case GL_LUMINANCE32F_ARB:
     case GL_R32F:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("GRAY32F"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("GRAY32F"));
       Download(unsafe_ptr, GL_RED, GL_FLOAT);
       break;
     case GL_RGB16:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("RGB48"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("RGB48"));
       Download(unsafe_ptr, GL_RGB, GL_UNSIGNED_SHORT);
       break;
     case GL_RGBA16:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("RGBA64"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("RGBA64"));
       Download(unsafe_ptr, GL_RGBA, GL_UNSIGNED_SHORT);
       break;
     case GL_RGB16F:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("RGB48F"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("RGB48F"));
       Download(unsafe_ptr, GL_RGB, GL_HALF_FLOAT);
       break;
     case GL_RGBA16F:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("RGBA64F"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("RGBA64F"));
       Download(unsafe_ptr, GL_RGBA, GL_HALF_FLOAT);
       break;
     case GL_RGB:
     case GL_RGB32F:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("RGB96F"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("RGB96F"));
       Download(unsafe_ptr, GL_RGB, GL_FLOAT);
       break;
     case GL_RGBA:
     case GL_RGBA32F:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("RGBA128F"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("RGBA128F"));
       Download(unsafe_ptr, GL_RGBA, GL_FLOAT);
       break;
     case GL_DEPTH_COMPONENT16:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("GRAY16LE"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("GRAY16LE"));
       Download(unsafe_ptr, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT);
       break;
     case GL_DEPTH_COMPONENT24:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("GRAY32"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("GRAY32"));
       Download(unsafe_ptr, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT);
       break;
     case GL_DEPTH_COMPONENT32F:
-      image = sophus::IntensityImage<>(size, PixelFormatFromString("GRAY32F"));
+      image = sophus::IntensityImage<>::fromFormat(
+          size, PixelFormatFromString("GRAY32F"));
       Download(unsafe_ptr, GL_DEPTH_COMPONENT, GL_FLOAT);
       break;
     default:

--- a/components/pango_opengl/include/pangolin/gl/gl_type_info.h
+++ b/components/pango_opengl/include/pangolin/gl/gl_type_info.h
@@ -62,11 +62,12 @@ inline farm_ng::Expected<GlFormatInfo> glTypeInfo(
   };
 
   // Make sure we'll be in bounds...
-  const int nbytes = pixel_type.num_bytes_per_pixel_channel;
+  const int nbytes = pixel_type.num_bytes_per_component;
   const bool bfixed = pixel_type.number_type == sophus::NumberType::fixed_point;
 
-  if (between(pixel_type.num_channels, 1, 4) && isOneOf(nbytes, {1, 2, 4})) {
-    const int cidx = pixel_type.num_channels - 1;
+  if (between(int(pixel_type.num_components), 1, 4) &&
+      isOneOf(nbytes, {1, 2, 4})) {
+    const int cidx = pixel_type.num_components - 1;
     const int fidx = (nbytes == 4 && bfixed) ? 2 : nbytes - 1;
     return GlFormatInfo(
         {.gl_sized_format = format_table[fidx][cidx],

--- a/components/pango_opengl/include/pangolin/gl/glpixformat.h
+++ b/components/pango_opengl/include/pangolin/gl/glpixformat.h
@@ -42,7 +42,7 @@ struct GlPixFormat {
 
   GlPixFormat(const sophus::PixelFormat& fmt)
   {
-    switch (fmt.num_channels) {
+    switch (fmt.num_components) {
       case 1:
         glformat = GL_RED;
         break;
@@ -63,7 +63,7 @@ struct GlPixFormat {
 
     const bool is_integral = fmt.number_type == sophus::NumberType::fixed_point;
 
-    switch (fmt.num_bytes_per_pixel_channel) {
+    switch (fmt.num_bytes_per_component) {
       case 1:
         gltype = GL_UNSIGNED_BYTE;
         break;

--- a/components/pango_opengl/src/gl_device_buffer.cpp
+++ b/components/pango_opengl/src/gl_device_buffer.cpp
@@ -190,7 +190,7 @@ struct DeviceGlBuffer : public DeviceBuffer {
 
   size_t elementSizeBytes() const
   {
-    return data_type_ ? data_type_->bytesPerPixel() : 0;
+    return data_type_ ? data_type_->numBytesPerPixel() : 0;
   }
 
   GLenum buffer_type_ = 0;

--- a/components/pango_opengl/src/gl_device_texture.cpp
+++ b/components/pango_opengl/src/gl_device_texture.cpp
@@ -126,9 +126,9 @@ struct DeviceGlTexture : public DeviceTexture {
     }
 
     // Upload data
-    const size_t stride = u.image.pitchBytes() / data_type.bytesPerPixel();
+    const size_t stride = u.image.pitchBytes() / data_type.numBytesPerPixel();
     PANGO_CHECK(
-        stride * data_type.bytesPerPixel() == u.image.pitchBytes(),
+        stride * data_type.numBytesPerPixel() == u.image.pitchBytes(),
         "Image pitch is not a multiple of the pixel size (which OpenGL "
         "requires).");
     PANGO_GL(glPixelStorei(GL_UNPACK_ROW_LENGTH, stride));

--- a/components/pango_opengl/src/gl_vao.cpp
+++ b/components/pango_opengl/src/gl_vao.cpp
@@ -85,11 +85,11 @@ void GlVertexArrayObject::addVertexAttrib(
 
   if (isGlIntegralDatatype(gl_fmt.gl_type)) {
     PANGO_GL(glVertexAttribIPointer(
-        attrib_location, data_type.num_channels, gl_fmt.gl_type, stride_bytes,
+        attrib_location, data_type.num_components, gl_fmt.gl_type, stride_bytes,
         (void*)offset_bytes));
   } else {
     PANGO_GL(glVertexAttribPointer(
-        attrib_location, data_type.num_channels, gl_fmt.gl_type, normalized,
+        attrib_location, data_type.num_components, gl_fmt.gl_type, normalized,
         stride_bytes, (void*)offset_bytes));
   }
   PANGO_GL(glEnableVertexAttribArray(attrib_location));

--- a/components/pango_render/include/pangolin/render/device_buffer.h
+++ b/components/pango_render/include/pangolin/render/device_buffer.h
@@ -34,7 +34,7 @@ struct DeviceBuffer {
   virtual void reserve(size_t) const = 0;
 
   // size of allocated buffer in bytes. Will be at least `capacity() *
-  // dataType().bytesPerPixel()`.
+  // dataType().numBytesPerPixel()`.
   virtual size_t sizeBytes() const = 0;
 
   // Queue upload of data into position `dest_element` of device buffer. The

--- a/components/pango_render/include/pangolin/render/shared_data_package.h
+++ b/components/pango_render/include/pangolin/render/shared_data_package.h
@@ -41,8 +41,8 @@ struct SharedDataPackage {
     using C = Eigen::Matrix<float, kRows, kCols>;
     data_type = {
         .number_type = sophus::NumberType::floating_point,
-        .num_channels = int(matrix.rows()),
-        .num_bytes_per_pixel_channel = sizeof(float),
+        .num_components = uint8_t(matrix.rows()),
+        .num_bytes_per_component = sizeof(float),
     };
     num_elements = matrix.cols();
     data = makeTypeErasedSharedPtr(std::forward<C>(matrix));

--- a/components/pango_video/include/pangolin/video/stream_info.h
+++ b/components/pango_video/include/pangolin/video/stream_info.h
@@ -35,7 +35,7 @@ namespace pangolin
 class PANGOLIN_EXPORT StreamInfo
 {
   public:
-  inline StreamInfo() : layout_(0, 0, 0), offset_bytes_(0) {}
+  inline StreamInfo() : layout_(), offset_bytes_(0) {}
 
   inline StreamInfo(
       sophus::PixelFormat fmt, const sophus::ImageLayout shape,
@@ -52,7 +52,7 @@ class PANGOLIN_EXPORT StreamInfo
 
   inline size_t rowBytes() const
   {
-    return format().bytesPerPixel() * layout().width();
+    return format().numBytesPerPixel() * layout().width();
   }
 
   //! Return Image wrapper around raw base pointer
@@ -69,11 +69,12 @@ class PANGOLIN_EXPORT StreamInfo
   inline sophus::IntensityImage<> copyToDynImage(const uint8_t* base_ptr) const
   {
     PANGO_DEBUG("Unneeded image copy happening...");
-    sophus::IntensityImage<> runtime(layout_, fmt_);
+    sophus::IntensityImage<> runtime =
+        sophus::IntensityImage<>::fromFormat(layout_, fmt_);
     sophus::details::pitchedCopy(
         const_cast<uint8_t*>(runtime.rawPtr()), runtime.layout().pitchBytes(),
         base_ptr, layout_.pitchBytes(), layout_.imageSize(),
-        fmt_.bytesPerPixel());
+        fmt_.numBytesPerPixel());
     return runtime;
   }
 

--- a/components/pango_video/include/pangolin/video/video_interface.h
+++ b/components/pango_video/include/pangolin/video/video_interface.h
@@ -88,13 +88,14 @@ struct PANGOLIN_EXPORT VideoInterface {
       std::vector<IntensityImage<>> res;
       // Allocation into seperate images too, ughhhhhh
       for (const auto& s : Streams()) {
-        res.emplace_back(ImageSize(s.layout().imageSize()), s.format());
+        res.push_back(sophus::IntensityImage<>::fromFormat(
+            ImageSize(s.layout().imageSize()), s.format()));
         auto& dst_image = res.back();
         sophus::details::pitchedCopy(
             const_cast<uint8_t*>(dst_image.rawPtr()),
             dst_image.layout().pitchBytes(), buffer.get() + s.offsetBytes(),
             s.layout().pitchBytes(), dst_image.imageSize(),
-            s.format().bytesPerPixel());
+            s.format().numBytesPerPixel());
       }
       return res;
     }

--- a/components/pango_video/src/drivers/ffmpeg.cpp
+++ b/components/pango_video/src/drivers/ffmpeg.cpp
@@ -268,7 +268,7 @@ void FfmpegVideo::InitUrl(
   {
     const sophus::PixelFormat strm_fmt =
         PixelFormatFromString(FfmpegFmtToString(fmtout));
-    const size_t pitch = strm_fmt.bytesPerPixel() * w;
+    const size_t pitch = strm_fmt.numBytesPerPixel() * w;
     const size_t size_bytes = h * pitch;
     streams.emplace_back(
         strm_fmt, sophus::ImageLayout(w, h, pitch), numBytesOut);

--- a/components/pango_video/src/drivers/images.cpp
+++ b/components/pango_video/src/drivers/images.cpp
@@ -49,7 +49,7 @@ bool ImagesVideo::LoadFrame(size_t i)
       if (file_type == ImageFileTypeUnknown && unknowns_are_raw) {
         // if raw_pitch is zero, assume image is packed.
         const size_t pitch =
-            raw_pitch ? raw_pitch : raw_fmt.bytesPerPixel() * raw_width;
+            raw_pitch ? raw_pitch : raw_fmt.numBytesPerPixel() * raw_width;
         frame.push_back(LoadImage(
             filename, raw_fmt, raw_width, raw_height, pitch, raw_offset,
             raw_planes));

--- a/components/pango_video/src/drivers/split.cpp
+++ b/components/pango_video/src/drivers/split.cpp
@@ -125,7 +125,7 @@ PANGOLIN_REGISTER_FACTORY(SplitVideo)
             throw VideoException("split: empty ROI.");
           }
           const size_t start1 = roi.y * st1.layout().pitchBytes() +
-                                st1.format().bytesPerPixel() * roi.x;
+                                st1.format().numBytesPerPixel() * roi.x;
           streams.push_back(StreamInfo(
               st1.format(),
               sophus::ImageLayout(roi.w, roi.h, st1.layout().pitchBytes()),
@@ -167,16 +167,18 @@ PANGOLIN_REGISTER_FACTORY(SplitVideo)
         }
 
         const size_t start1 = roi1.y * st1.layout().pitchBytes() +
-                              st1.format().bytesPerPixel() * roi1.x;
+                              st1.format().numBytesPerPixel() * roi1.x;
         const size_t start2 = roi2.y * st1.layout().pitchBytes() +
-                              st1.format().bytesPerPixel() * roi2.x;
+                              st1.format().numBytesPerPixel() * roi2.x;
         streams.push_back(StreamInfo(
             st1.format(),
-            sophus::ImageLayout(roi1.w, roi1.h, st1.layout().pitchBytes()),
+            sophus::ImageLayout(
+                sophus::ImageSize(roi1.w, roi1.h), st1.layout().pitchBytes()),
             start1));
         streams.push_back(StreamInfo(
             st1.format(),
-            sophus::ImageLayout(roi2.w, roi2.h, st1.layout().pitchBytes()),
+            sophus::ImageLayout(
+                sophus::ImageSize(roi2.w, roi2.h), st1.layout().pitchBytes()),
             start2));
       }
 

--- a/components/pango_video/src/drivers/test.cpp
+++ b/components/pango_video/src/drivers/test.cpp
@@ -44,8 +44,7 @@ TestVideo::TestVideo(size_t w, size_t h, size_t n, const std::string& pix_fmt)
 {
   const sophus::PixelFormat pfmt = PixelFormatFromString(pix_fmt.c_str());
   const sophus::ImageLayout shape =
-      sophus::ImageLayout::makeFromSizeAndPitchUnchecked(
-          sophus::ImageSize(w, h), w * pfmt.bytesPerPixel());
+      sophus::ImageLayout(sophus::ImageSize(w, h), w * pfmt.numBytesPerPixel());
 
   size_bytes = 0;
 

--- a/components/pango_video/src/drivers/transform.cpp
+++ b/components/pango_video/src/drivers/transform.cpp
@@ -453,7 +453,7 @@ void TransformVideo::Process(uint8_t* buffer_out, const uint8_t* buffer_in)
     MutImageView<uint8_t> img_out = Streams()[s].StreamImage(buffer_out);
     const ImageView<uint8_t> img_in =
         videoin->Streams()[s].StreamImage(buffer_in);
-    const size_t bytes_per_pixel = Streams()[s].format().bytesPerPixel();
+    const size_t bytes_per_pixel = Streams()[s].format().numBytesPerPixel();
 
     switch (flips[s]) {
       case TransformOptions::FlipX:

--- a/components/pango_video/src/video_output.cpp
+++ b/components/pango_video/src/video_output.cpp
@@ -78,9 +78,7 @@ void VideoOutput::AddStream(
 void VideoOutput::AddStream(
     const sophus::PixelFormat& pf, sophus::ImageSize size)
 {
-  AddStream(
-      pf, sophus::ImageLayout::makeFromSizeAndPitchUnchecked(
-              size, size.width * pf.bytesPerPixel()));
+  AddStream(pf, sophus::ImageLayout(size, size.width * pf.numBytesPerPixel()));
 }
 
 void VideoOutput::SetStreams(


### PR DESCRIPTION
I believe the issue with the current implementation is that when indices are specified as a `std::vector<Eigen::Matrix<uint32_t, 3, 1>>`, we run into Eigen alignment issues, i.e. http://eigen.tuxfamily.org/dox-devel/group__TopicFixedSizeVectorizable.html.

I'm not sure what deeper fixes might be necessary to prevent, or fix that usage in the API, but this is a solution for the Icosphere at least; indices are specified as `std::vector<unsigned int>`.

before and after, white icosphere with 4 subdivisions next to default cube:
![before](https://user-images.githubusercontent.com/601482/229320037-fa64aa2a-50bd-49c3-8584-7655dddfd3b9.png)
![after](https://user-images.githubusercontent.com/601482/229320039-e2ec365d-18a9-4c01-9902-6315ac36cac4.png)

 