### PR TITLE
Add env var to skip binding ESC to quit Pangolin

### DIFF
--- a/components/pango_display/src/display.cpp
+++ b/components/pango_display/src/display.cpp
@@ -182,7 +182,13 @@ void RegisterNewContext(const std::string& name, std::shared_ptr<PangolinGl> new
     context = newcontext.get();
 
     // Default key bindings can be overridden
-    RegisterKeyPressCallback(PANGO_KEY_ESCAPE, Quit );
+    // Only set the escape key to quit if PANGOLIN_BIND_ESC_TO_QUIT is not set, or is set to 1.
+    const char* bind_esc = std::getenv("PANGOLIN_BIND_ESC_TO_QUIT");
+    if( bind_esc == nullptr || std::string(bind_esc) == "1" )
+    {
+        RegisterKeyPressCallback(PANGO_KEY_ESCAPE, Quit );
+    }
+
     RegisterKeyPressCallback('\t', [](){ShowFullscreen(TrueFalseToggle::Toggle);} );
     RegisterKeyPressCallback('`',  [](){ShowConsole(TrueFalseToggle::Toggle);} );
 


### PR DESCRIPTION
Setting PANGOLIN_BIND_ESC_TO_QUIT to anything but `1` will skip binding the escape key to the quit function of Pangolin. For backward compatibility, not setting this environment variable will keep the previous behavior, i.e., pressing escape will quit pangolin