### PR TITLE
Add inline to varextra's checkReset()

### DIFF
--- a/components/pango_context/src/context.cpp
+++ b/components/pango_context/src/context.cpp
@@ -418,8 +418,9 @@ struct ContextImpl : public Context {
       ImageXy image_axis_convention) const override
   {
     using namespace sophus;
-    if(bounds.isEmpty()) {
-      bounds = Region2I::fromMinMax({0,0}, {size().width-1, size().height-1});
+    if (bounds.isEmpty()) {
+      bounds =
+          Region2I::fromMinMax({0, 0}, {size().width - 1, size().height - 1});
     }
 
     const auto gl_bounds =

--- a/components/pango_vars/include/pangolin/var/varextra.h
+++ b/components/pango_vars/include/pangolin/var/varextra.h
@@ -101,7 +101,7 @@ inline bool checkPushed(Var<bool>& var)
 
 // Return true if any of the pangolin variables are set.
 // Additionally, resets the 'gui_changed' flag on all input variables.
-bool checkReset() { return false; }
+inline bool checkReset() { return false; }
 template <typename Var, typename... Rest>
 bool checkReset(Var& var, Rest&... rest)
 {


### PR DESCRIPTION
Fixes a linker error 
```
[build] /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/deque.tcc:770: multiple definition of pangolin::checkReset();
```

CI was failing due to pre-commit format check; I pushed a fix for that to this PR as well. 