### PR TITLE
fix wayland subsurface

### DIFF
--- a/.github/workflows/ros_workspace.yml
+++ b/.github/workflows/ros_workspace.yml
@@ -24,21 +24,21 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup ROS environment
-        uses: ros-tooling/setup-ros@v0.3
+        uses: ros-tooling/setup-ros@v0.7
 
       - name: ROS 1 CI Action
         if: ${{ matrix.ros_version == 1 }}
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: ros-tooling/action-ros-ci@v0.3
         with:
           package-name: pangolin
           target-ros1-distro: ${{ matrix.ros_distribution }}
 
       - name: ROS 2 CI Action
         if: ${{ matrix.ros_version == 2 }}
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: ros-tooling/action-ros-ci@v0.3
         with:
           package-name: pangolin
           target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/components/pango_windowing/src/display_wayland.cpp
+++ b/components/pango_windowing/src/display_wayland.cpp
@@ -246,6 +246,8 @@ struct Decoration {
     { }
 
     void create() {
+        destroy();
+
         // reserve memory to prevent that DecorationSurface's destructor gets
         // called by 'emplace_back'
         decorations.reserve(9);

--- a/components/pango_windowing/src/display_wayland.cpp
+++ b/components/pango_windowing/src/display_wayland.cpp
@@ -278,6 +278,10 @@ struct Decoration {
         buttons.clear();
     }
 
+    bool visible() {
+        return !(decorations.empty() && buttons.empty());
+    }
+
     void resize(const int32_t width, const int32_t height) {
         for(const DecorationSurface &d : decorations) { d.resize(width, height); }
         for(const ButtonSurface &b : buttons) { b.reposition(width); }
@@ -537,6 +541,11 @@ static void handle_configure_toplevel(void *data, struct xdg_toplevel */*xdg_top
 
 static void handle_configure(void *data, struct xdg_surface *xdg_surface, uint32_t serial) {
     WaylandWindow* const w = static_cast<WaylandWindow*>(data);
+
+    if (w->is_fullscreen && w->decoration->visible())
+        w->decoration->destroy();
+    else if (!w->is_fullscreen && !w->decoration->visible())
+        w->decoration->create();
 
     // resize main surface
     wl_egl_window_resize(w->egl_window, w->width, w->height, 0, 0);

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>pangolin</name>
   <version>0.8.0</version>
   <description>Pangolin is a set of lightweight and portable utility libraries for prototyping 3D, numeric or video based programs and algorithms.</description>
@@ -13,6 +13,9 @@
   <depend>libglew-dev</depend>
   <depend>python3-dev</depend>
   <build_depend>eigen</build_depend>
+  <depend>libpng-dev</depend>
+  <depend>libturbojpeg</depend>
+  <depend>libxkbcommon-dev</depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -4,6 +4,7 @@
   <version>0.8.0</version>
   <description>Pangolin is a set of lightweight and portable utility libraries for prototyping 3D, numeric or video based programs and algorithms.</description>
   <maintainer email="stevenlovegrove@gmail.com">Steven Lovegrove</maintainer>
+  <maintainer email="Rauch.Christian@gmx.de">Christian Rauch</maintainer>
   <author     email="stevenlovegrove@gmail.com">Steven Lovegrove</author>
   <license>MIT</license>
 


### PR DESCRIPTION
This fixes an issue in the Wayland windowing when decorations are created multiple times without first destroying them. Also, parts of the CI pipeline used outdated actions which are updated with this PR.