### PR TITLE
Wayland compile and runtime dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,8 @@
   <depend>libpng-dev</depend>
   <depend>libturbojpeg</depend>
   <depend>libxkbcommon-dev</depend>
+  <build_depend>wayland-dev</build_depend>
+  <exec_depend>wayland</exec_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
This adds the Wayland dependencies to the `package.xml` to enable the automatic installation of those dependencies via rosdep and for bloom.