### PR TITLE
enabled tests on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,8 @@ jobs:
       run: cmake --build build --config $BUILD_TYPE
 
     - name: Run all tests
-      working-directory: ${{runner.workspace}}/Pangolin/build
-      run: ctest
+      run: |
+        cmake --build build --target test
 
   emscripten:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,15 @@ jobs:
         include:
         - os: ubuntu-22.04
           package_manager: "apt"
+          test: "ON"
 
         - os: macos-13
           package_manager: "brew"
+          test: "OFF"
 
         - os: windows-2022
           package_manager: "vcpkg"
+          test: "OFF"
 
     steps:
     - name: Checkout Pangolin
@@ -57,12 +60,13 @@ jobs:
 
     - name: Configure CMake
       run: |
-        cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" -DBUILD_TESTS=ON
+        cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" -DBUILD_TESTS=${{matrix.test}}
 
     - name: Build
       run: cmake --build build --config $BUILD_TYPE
 
     - name: Run all tests
+      if: ${{ matrix.test == 'ON' }}
       run: |
         cmake --build build --target test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           package_manager: "apt"
 
         - os: macos-13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
     - name: install build dependencies
       run: |
         sudo apt update
-        sudo apt install -y emscripten ninja-build libeigen3-dev
+        sudo apt install -y emscripten ninja-build libeigen3-dev catch2
 
     - name: Configure Pangolin
       run: emcmake cmake -G Ninja -B pangolin-build -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D Eigen3_DIR=/usr/share/eigen3/cmake/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,16 +87,11 @@ endif()
 #######################################################
 ## Testing setup
 
-option( BUILD_TESTS "Build Tests" OFF)
-find_package(Catch2 2 QUIET)
-if(Catch2_FOUND)
+option(BUILD_TESTS "Build Tests" OFF)
+if(BUILD_TESTS)
+    find_package(Catch2 2 REQUIRED)
     include(CTest)
     include(Catch)
-else()
-    if(BUILD_TESTS)
-        message(WARNING "Building Tests requested, but Catch2 library not found.")
-        set( BUILD_TESTS OFF)
-    endif()
 endif()
 
 #######################################################

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ cmake --build build
 cmake --build build -t pypangolin_pip_install
 
 # Run me some tests! (Requires Catch2 which must be manually installed on Ubuntu.)
+cmake -B build -G Ninja -D BUILD_TESTS=ON
+cmake --build build
+cd build
 ctest
 ```
 

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
   <build_depend>wayland-dev</build_depend>
   <exec_depend>wayland</exec_depend>
 
+  <test_depend>catch2</test_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -123,7 +123,7 @@ if [[ "$MANAGER" == "apt" ]]; then
     PKGS_REQUIRED+=(libc++-dev libglew-dev libeigen3-dev cmake g++ ninja-build)
     PKGS_RECOMMENDED+=(libjpeg-dev libpng-dev)
     PKGS_RECOMMENDED+=(libavcodec-dev libavutil-dev libavformat-dev libswscale-dev libavdevice-dev)
-    PKGS_ALL+=(libdc1394-22-dev libraw1394-dev libopenni-dev python3.9-dev python3-distutils)
+    PKGS_ALL+=(libdc1394-dev libraw1394-dev libopenni-dev python3-dev python3-distutils)
 elif [[ "$MANAGER" == "dnf" ]]; then
     SUDO="sudo"
     PKGS_UPDATE="dnf check-update"
@@ -131,7 +131,7 @@ elif [[ "$MANAGER" == "dnf" ]]; then
     PKGS_REQUIRED+=(wayland-devel libxkbcommon-devel g++ ninja-build)
     PKGS_REQUIRED+=(glew-devel eigen3 cmake)
     PKGS_RECOMMENDED+=(libjpeg-devel libpng-devel OpenEXR-devel)
-    PKGS_ALL+=(libdc1394-22-devel libraw1394-devel librealsense-devel openni-devel)
+    PKGS_ALL+=(libdc1394-devel libraw1394-devel librealsense-devel openni-devel)
     if ((DRYRUN > 0));  then
         MANAGER="echo $MANAGER"
         SUDO=""
@@ -142,7 +142,7 @@ elif [[ "$MANAGER" == "pacman" ]]; then
     PKGS_OPTIONS+=(-Syu)
     PKGS_REQUIRED+=(mesa wayland libxkbcommon wayland-protocols libc++ glew eigen cmake gcc ninja)
     PKGS_RECOMMENDED+=(libjpeg-turbo libpng ffmpeg)
-    PKGS_ALL+=(libdc1394 libraw1394 openni python39 python-distutils-extra)
+    PKGS_ALL+=(libdc1394 libraw1394 openni python3 python-distutils-extra)
     if ((DRYRUN > 0));  then
         MANAGER="echo $MANAGER"
         SUDO=""

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -121,7 +121,7 @@ if [[ "$MANAGER" == "apt" ]]; then
     if ((DRYRUN > 0));  then PKGS_OPTIONS+=(--dry-run); SUDO=""; fi
     PKGS_REQUIRED+=(libgl1-mesa-dev libwayland-dev libxkbcommon-dev wayland-protocols libegl1-mesa-dev)
     PKGS_REQUIRED+=(libc++-dev libglew-dev libeigen3-dev cmake g++ ninja-build)
-    PKGS_RECOMMENDED+=(libjpeg-dev libpng-dev)
+    PKGS_RECOMMENDED+=(libjpeg-dev libpng-dev catch2)
     PKGS_RECOMMENDED+=(libavcodec-dev libavutil-dev libavformat-dev libswscale-dev libavdevice-dev)
     PKGS_ALL+=(libdc1394-dev libraw1394-dev libopenni-dev python3-dev python3-distutils)
 elif [[ "$MANAGER" == "dnf" ]]; then
@@ -130,7 +130,7 @@ elif [[ "$MANAGER" == "dnf" ]]; then
     PKGS_OPTIONS+=(install)
     PKGS_REQUIRED+=(wayland-devel libxkbcommon-devel g++ ninja-build)
     PKGS_REQUIRED+=(glew-devel eigen3 cmake)
-    PKGS_RECOMMENDED+=(libjpeg-devel libpng-devel OpenEXR-devel)
+    PKGS_RECOMMENDED+=(libjpeg-devel libpng-devel OpenEXR-devel catch2)
     PKGS_ALL+=(libdc1394-devel libraw1394-devel librealsense-devel openni-devel)
     if ((DRYRUN > 0));  then
         MANAGER="echo $MANAGER"


### PR DESCRIPTION
The tests have effectively been disabled in the CI as Catch2 was not installed on Ubuntu and Windows and macOS installed a newer version that CMake would ignore to use. This PR installs Catch2 on Ubuntu 22.04 via the package manager and activates the test for Ubuntu on the CI. For Windows and macOS, Catch2 v3 has to be used and for this, the tests have to be upgraded.

Fixes #847.