### PR TITLE
Fix packetstream_tags Build On gnu++14

### DIFF
--- a/components/pango_packetstream/include/pangolin/log/packetstream_tags.h
+++ b/components/pango_packetstream/include/pangolin/log/packetstream_tags.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <stdint.h>
 
 namespace pangolin {
 


### PR DESCRIPTION
 - error: ‘uint32_t’ does not name a type in packetstream_tags.h

```
[2/113] /usr/bin/g++ -Dpangolin_EXPORTS -I/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include -I/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/redhat-linux-build/src/include -Wall -Wno-error=deprecated-declarations -Wall -Wextra -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64   -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DNDEBUG -std=gnu++14 -fPIC -MD -MT src/CMakeFiles/pangolin.dir/log/packetstream.cpp.o -MF src/CMakeFiles/pangolin.dir/log/packetstream.cpp.o.d -o src/CMakeFiles/pangolin.dir/log/packetstream.cpp.o -c /builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp
FAILED: src/CMakeFiles/pangolin.dir/log/packetstream.cpp.o 
/usr/bin/g++ -Dpangolin_EXPORTS -I/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include -I/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/redhat-linux-build/src/include -Wall -Wno-error=deprecated-declarations -Wall -Wextra -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64   -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DNDEBUG -std=gnu++14 -fPIC -MD -MT src/CMakeFiles/pangolin.dir/log/packetstream.cpp.o -MF src/CMakeFiles/pangolin.dir/log/packetstream.cpp.o.d -o src/CMakeFiles/pangolin.dir/log/packetstream.cpp.o -c /builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp
In file included from /builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream.h:32,
                 from /builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:1:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:7:22: error: ‘uint32_t’ does not name a type
    7 | using pangoTagType = uint32_t;
      |                      ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:1:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
  +++ |+#include <cstdint>
    1 | #pragma once
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:25:7: error: ‘uint32_t’ does not name a type
   25 | const uint32_t TAG_PANGO_HDR    = PANGO_TAG('L', 'I', 'N');
      |       ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:25:7: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:26:7: error: ‘uint32_t’ does not name a type
   26 | const uint32_t TAG_PANGO_MAGIC  = PANGO_TAG('P', 'A', 'N');
      |       ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:26:7: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:27:7: error: ‘uint32_t’ does not name a type
   27 | const uint32_t TAG_PANGO_SYNC   = PANGO_TAG('S', 'Y', 'N');
      |       ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:27:7: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:28:7: error: ‘uint32_t’ does not name a type
   28 | const uint32_t TAG_PANGO_STATS  = PANGO_TAG('S', 'T', 'A');
      |       ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:28:7: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:29:7: error: ‘uint32_t’ does not name a type
   29 | const uint32_t TAG_PANGO_FOOTER = PANGO_TAG('F', 'T', 'R');
      |       ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:29:7: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:30:7: error: ‘uint32_t’ does not name a type
   30 | const uint32_t TAG_ADD_SOURCE   = PANGO_TAG('S', 'R', 'C');
      |       ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:30:7: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:31:7: error: ‘uint32_t’ does not name a type
   31 | const uint32_t TAG_SRC_JSON     = PANGO_TAG('J', 'S', 'N');
      |       ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:31:7: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:32:7: error: ‘uint32_t’ does not name a type
   32 | const uint32_t TAG_SRC_PACKET   = PANGO_TAG('P', 'K', 'T');
      |       ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:32:7: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:33:7: error: ‘uint32_t’ does not name a type
   33 | const uint32_t TAG_END          = PANGO_TAG('E', 'N', 'D');
      |       ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream_tags.h:33:7: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream.h:88:5: error: ‘pangoTagType’ does not name a type
   88 |     pangoTagType peekTag();
      |     ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream.h:90:5: error: ‘pangoTagType’ does not name a type
   90 |     pangoTagType readTag();
      |     ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream.h:92:5: error: ‘pangoTagType’ does not name a type
   92 |     pangoTagType readTag(pangoTagType);
      |     ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream.h:94:5: error: ‘pangoTagType’ does not name a type
   94 |     pangoTagType syncToTag();
      |     ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream.h:100:5: error: ‘pangoTagType’ does not name a type
  100 |     pangoTagType _tag;
      |     ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream.h: In member function ‘void pangolin::PacketStream::cclear()’:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/include/pangolin/log/packetstream.h:106:9: error: ‘_tag’ was not declared in this scope
  106 |         _tag = 0;
      |         ^~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp: In member function ‘size_t pangolin::PacketStream::readUINT()’:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:10:5: error: ‘uint32_t’ was not declared in this scope
   10 |     uint32_t shift = 0;
      |     ^~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:2:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    1 | #include <pangolin/log/packetstream.h>
  +++ |+#include <cstdint>
    2 | #include <stdexcept>
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:13:28: error: ‘shift’ was not declared in this scope
   13 |         n |= (v & 0x7F) << shift;
      |                            ^~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:19:30: error: ‘shift’ was not declared in this scope
   19 |     return n | (v & 0x7F) << shift;
      |                              ^~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp: At global scope:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:29:1: error: ‘pangoTagType’ does not name a type
   29 | pangoTagType PacketStream::readTag()
      | ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:36:1: error: ‘pangoTagType’ does not name a type
   36 | pangoTagType PacketStream::readTag(pangoTagType x)
      | ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:44:1: error: ‘pangoTagType’ does not name a type
   44 | pangoTagType PacketStream::peekTag()
      | ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp: In member function ‘char pangolin::PacketStream::get()’:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:58:5: error: ‘_tag’ was not declared in this scope
   58 |     _tag = 0;
      |     ^~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp: In member function ‘size_t pangolin::PacketStream::read(char*, size_t)’:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:64:5: error: ‘_tag’ was not declared in this scope
   64 |     _tag = 0;
      |     ^~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp: In member function ‘std::streampos pangolin::PacketStream::tellg()’:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:82:9: error: ‘_tag’ was not declared in this scope
   82 |     if (_tag) {
      |         ^~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp: At global scope:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:105:19: error: ‘pangoTagType’ was not declared in this scope
  105 | static bool valid(pangoTagType t)
      |                   ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:124:1: error: ‘pangoTagType’ does not name a type
  124 | pangoTagType PacketStream::syncToTag() //scan through chars one by one until the last three look like a tag
      | ^~~~~~~~~~~~
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp: In member function ‘std::streampos pangolin::PacketStream::tellg()’:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:87:1: warning: control reaches end of non-void function [-Wreturn-type]
   87 | }
      | ^
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp: At global scope:
/builddir/build/BUILD/Pangolin-86eb4975fc4fc8b5d92148c2e370045ae9bf9f5d/src/log/packetstream.cpp:105:13: warning: ‘pangolin::valid’ defined but not used [-Wunused-variable]
  105 | static bool valid(pangoTagType t)
      |             ^~~~~
```