### PR TITLE
Test ci macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,8 @@ jobs:
         echo "TOOLCHAIN_FILE=$TOOLCHAIN_FILE" >> $GITHUB_ENV
 
     - name: Install Dependencies
+      env:
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
         echo "vcpkg location: $(which vcpkg)"
         echo "CMake toolchain file: $TOOLCHAIN_FILE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,20 @@ jobs:
         echo "${{github.workspace}}/scripts/vcpkg" >> $GITHUB_PATH
         echo "TOOLCHAIN_FILE=$TOOLCHAIN_FILE" >> $GITHUB_ENV
 
+    - name: "(brew only) Remove Python symlinks"
+      if: ${{ matrix.package_manager == 'brew' }}
+      run: |
+        rm /usr/local/bin/2to3
+        rm /usr/local/bin/2to3-3.12
+        rm /usr/local/bin/idle3
+        rm /usr/local/bin/idle3.12
+        rm /usr/local/bin/pydoc3
+        rm /usr/local/bin/pydoc3.12
+        rm /usr/local/bin/python3
+        rm /usr/local/bin/python3.12
+        rm /usr/local/bin/python3-config
+        rm /usr/local/bin/python3.12-config
+
     - name: Install Dependencies
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1


### PR DESCRIPTION
Recently the brew installation on the macOS CI failed with:
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.12

To list all files that would be deleted:
  brew link --overwrite python@3.12 --dry-run
```
and other Python related symlinks in `/usr/local/bin/`.

It's not entirely clear why this happens now without any change to the install script but removing these symlinks just before running brew seems to solve the issue.