### PR TITLE
update macOS on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
         shared_libs: ['ON', 'OFF']
         include:
         - os: ubuntu-22.04
           package_manager: "apt"
           test: "ON"
 
-        - os: macos-13
+        - os: macos-14
           package_manager: "brew"
           test: "OFF"
 


### PR DESCRIPTION
This switches to the newer macOS 14 runner on the arm64 platform.