### PR TITLE
test wheel file installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,15 @@ jobs:
     - name: Build Python wheel
       run: cmake --build build -t pypangolin_wheel
 
+    - name: Install Python wheel
+      if: ${{ matrix.package_manager == 'apt' }}
+      env:
+        PIP_BREAK_SYSTEM_PACKAGES: 1
+      run: |
+        pip install build/pypangolin-*.whl
+        pip show pypangolin
+        python -c "import pypangolin"
+
     - name: Run all tests
       if: ${{ matrix.test == 'ON' }}
       run: |

--- a/components/pango_python/CMakeLists.txt
+++ b/components/pango_python/CMakeLists.txt
@@ -44,10 +44,10 @@ if(BUILD_PANGOLIN_PYTHON AND Python_FOUND AND pybind11_FOUND)
     )
 
     target_sources(
-        ${COMPONENT} PRIVATE 
+        ${COMPONENT} PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src/pyinterpreter.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin_embed.cpp 
-        ${SRC_BINDINGS} 
+        ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin_embed.cpp
+        ${SRC_BINDINGS}
     )
 
     target_compile_definitions(${COMPONENT} PUBLIC HAVE_PYTHON)

--- a/components/pango_python/CMakeLists.txt
+++ b/components/pango_python/CMakeLists.txt
@@ -92,7 +92,7 @@ if(BUILD_PANGOLIN_PYTHON AND Python_FOUND AND pybind11_FOUND)
         AUTHOR "Steven Lovegrove"
         EMAIL "stevenlovegrove@gmail.com"
         LICENCE "MIT"
-        REQUIRES "pyopengl;pyopengl-accelerate;numpy;pillow;pybind11"
+        REQUIRES "pyopengl;numpy;pillow;pybind11"
         PRINT_HELP
     )
 else()


### PR DESCRIPTION
Install the built wheel file in the CI to test dependency issues.

I am also removing the dependency on `PyOpenGL-accelerate` due to the Cython compilation errors with Ubuntu 24.04 onwards (https://github.com/stevenlovegrove/Pangolin/issues/947#issuecomment-2325220668).

Fixes https://github.com/stevenlovegrove/Pangolin/issues/947.