### PR TITLE
fix wheel name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,10 @@ jobs:
         python -m zipfile --list build/pypangolin-*.whl
         pip install build/pypangolin-*.whl
         pip show pypangolin
+
+    - name: Test Python wheel
+      if: ${{ !(matrix.package_manager == 'vcpkg' && matrix.shared_libs == 'ON') }}
+      run: |
         python -c "import pypangolin"
 
     - name: Run all tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,21 @@ jobs:
         echo "CMake toolchain file: $TOOLCHAIN_FILE"
         $GITHUB_WORKSPACE/scripts/install_prerequisites.sh -v -u -m ${{matrix.package_manager}} all
 
+    - name: "(vcpkg only) remove python"
+      if: ${{ matrix.package_manager == 'vcpkg' }}
+      run: |
+        vcpkg remove python3
+
+    - uses: actions/setup-python@v5
+      if: ${{ matrix.package_manager == 'vcpkg' }}
+      with:
+        python-version: '3.12'
+
+    - name: "(vcpkg only) install setuptools"
+      if: ${{ matrix.package_manager == 'vcpkg' }}
+      run: |
+        pip install setuptools
+
     - name: Configure CMake
       run: >
         cmake -G Ninja -B build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
         sudo apt install -y emscripten ninja-build libeigen3-dev catch2
 
     - name: Configure Pangolin
-      run: emcmake cmake -G Ninja -B pangolin-build -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D Eigen3_DIR=/usr/share/eigen3/cmake/
+      run: emcmake cmake -G Ninja -B pangolin-build -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D BUILD_PANGOLIN_PYTHON=OFF -D Eigen3_DIR=/usr/share/eigen3/cmake/
 
     - name: Build Pangolin
       run: cmake --build pangolin-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,19 +21,15 @@ jobs:
         include:
         - os: ubuntu-22.04
           package_manager: "apt"
-          test: "ON"
 
         - os: ubuntu-24.04
           package_manager: "apt"
-          test: "ON"
 
         - os: macos-14
           package_manager: "brew"
-          test: "OFF"
 
         - os: windows-2022
           package_manager: "vcpkg"
-          test: "OFF"
 
     steps:
     - name: Checkout Pangolin
@@ -101,7 +97,7 @@ jobs:
         -D CMAKE_BUILD_TYPE=$BUILD_TYPE
         -D CMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
         -D BUILD_SHARED_LIBS=${{ matrix.shared_libs }}
-        -D BUILD_TESTS=${{ matrix.test }}
+        -D BUILD_TESTS=ON
 
     - name: Build
       run: cmake --build build --config $BUILD_TYPE
@@ -123,7 +119,6 @@ jobs:
         python -c "import pypangolin"
 
     - name: Run all tests
-      if: ${{ matrix.test == 'ON' }}
       run: |
         cmake --build build --target test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,6 @@ jobs:
       run: cmake --build build -t pypangolin_wheel
 
     - name: Install Python wheel
-      if: ${{ matrix.package_manager == 'apt' }}
       env:
         PIP_BREAK_SYSTEM_PACKAGES: 1
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
       env:
         PIP_BREAK_SYSTEM_PACKAGES: 1
       run: |
+        python -m zipfile --list build/pypangolin-*.whl
         pip install build/pypangolin-*.whl
         pip show pypangolin
         python -c "import pypangolin"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 project("Pangolin")
 set(PANGOLIN_VERSION_MAJOR 0)

--- a/cmake/MakePythonWheel.cmake
+++ b/cmake/MakePythonWheel.cmake
@@ -23,9 +23,9 @@ def wheel_name(**kwargs):
     # assemble wheel file name
     distname = bdist_wheel_cmd.wheel_dist_name
     tag = '-'.join(bdist_wheel_cmd.get_tag())
-    return f'{distname};{tag}'
+    return f'{distname}-{tag}'
 
-print(wheel_name(name='${python_module}', version='${version}', ext_modules=[Extension('dummy', ['summy.c'])]))
+print(wheel_name(name='${python_module}', version='${version}', ext_modules=[Extension('dummy', ['dummy.c'])]))
 "
         OUTPUT_VARIABLE wheel_filename
         OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -33,14 +33,10 @@ print(wheel_name(name='${python_module}', version='${version}', ext_modules=[Ext
     )
     if(NOT wheel_filename)
         message(STATUS "Python module `setuptools` required for correct wheel filename generation. Please install if needed.")
-        set(wheel_filename "unknown;unknown")
+        set(wheel_filename "unknown-unknown")
     endif()
 
-    list(GET wheel_filename 0 distname)
-    list(GET wheel_filename 1 platformtag)
-    set(complete_tag "${distname}-${platformtag}")
-
-    set(wheel_filename "${CMAKE_BINARY_DIR}/${complete_tag}.whl")
+    set(wheel_filename "${CMAKE_BINARY_DIR}/${wheel_filename}.whl")
     set(wheel_distinfo "${CMAKE_BINARY_DIR}/${python_module}-${version}.dist-info")
     set(wheel_data "${CMAKE_BINARY_DIR}/${python_module}-${version}.data")
     set(wheel_generator_string "pango_wheelgen_${version}")

--- a/cmake/MakePythonWheel.cmake
+++ b/cmake/MakePythonWheel.cmake
@@ -9,7 +9,19 @@ function( MakeWheel python_module)
     cmake_parse_arguments(MAKEWHEEL "PRINT_HELP" "MODULE;VERSION;SUMMARY;DESCRIPTION;HOMEPAGE;AUTHOR;EMAIL;LICENCE" "REQUIRES" ${ARGN} )
     set(version ${MAKEWHEEL_VERSION})
 
-    execute_process(COMMAND ${Python3_EXECUTABLE} -c "import setuptools" ERROR_QUIET RESULT_VARIABLE has_setuptools)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -c "
+import sys
+try:
+    import setuptools
+    sys.exit(0)
+except ImportError as e:
+    print(f'{e}. Search paths:', file=sys.stderr)
+    for p in sys.path: print(f'  {p}', file=sys.stderr)
+    sys.exit(1)
+"
+    RESULT_VARIABLE has_setuptools)
+
     if(has_setuptools EQUAL "1")
         message(FATAL_ERROR "Python module `setuptools` required for correct wheel filename generation.")
     endif()

--- a/cmake/MakePythonWheel.cmake
+++ b/cmake/MakePythonWheel.cmake
@@ -9,13 +9,13 @@ function( MakeWheel python_module)
     cmake_parse_arguments(MAKEWHEEL "PRINT_HELP" "MODULE;VERSION;SUMMARY;DESCRIPTION;HOMEPAGE;AUTHOR;EMAIL;LICENCE" "REQUIRES" ${ARGN} )
     set(version ${MAKEWHEEL_VERSION})
 
-    execute_process(COMMAND ${Python_EXECUTABLE} -c "import setuptools" ERROR_QUIET RESULT_VARIABLE has_setuptools)
+    execute_process(COMMAND ${Python3_EXECUTABLE} -c "import setuptools" ERROR_QUIET RESULT_VARIABLE has_setuptools)
     if(has_setuptools EQUAL "1")
         message(FATAL_ERROR "Python module `setuptools` required for correct wheel filename generation.")
     endif()
 
     execute_process(
-        COMMAND ${Python_EXECUTABLE} -c "
+        COMMAND ${Python3_EXECUTABLE} -c "
 from setuptools.dist import Distribution
 from setuptools import Extension
 

--- a/cmake/MakePythonWheel.cmake
+++ b/cmake/MakePythonWheel.cmake
@@ -9,6 +9,11 @@ function( MakeWheel python_module)
     cmake_parse_arguments(MAKEWHEEL "PRINT_HELP" "MODULE;VERSION;SUMMARY;DESCRIPTION;HOMEPAGE;AUTHOR;EMAIL;LICENCE" "REQUIRES" ${ARGN} )
     set(version ${MAKEWHEEL_VERSION})
 
+    execute_process(COMMAND ${Python_EXECUTABLE} -c "import setuptools" ERROR_QUIET RESULT_VARIABLE has_setuptools)
+    if(has_setuptools EQUAL "1")
+        message(FATAL_ERROR "Python module `setuptools` required for correct wheel filename generation.")
+    endif()
+
     execute_process(
         COMMAND ${Python_EXECUTABLE} -c "
 from setuptools.dist import Distribution
@@ -31,10 +36,6 @@ print(wheel_name(name='${python_module}', version='${version}', ext_modules=[Ext
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_QUIET
     )
-    if(NOT wheel_filename)
-        message(STATUS "Python module `setuptools` required for correct wheel filename generation. Please install if needed.")
-        set(wheel_filename "unknown-unknown")
-    endif()
 
     set(wheel_filename "${CMAKE_BINARY_DIR}/${wheel_filename}.whl")
     set(wheel_distinfo "${CMAKE_BINARY_DIR}/${python_module}-${version}.dist-info")

--- a/components/pango_python/CMakeLists.txt
+++ b/components/pango_python/CMakeLists.txt
@@ -3,10 +3,13 @@ get_filename_component(COMPONENT ${CMAKE_CURRENT_LIST_DIR} NAME)
 option(BUILD_PANGOLIN_PYTHON "Build support for Pangolin Interactive Console" ON)
 
 if(BUILD_PANGOLIN_PYTHON)
-  find_package(Python COMPONENTS Interpreter Development QUIET)
+  if(POLICY CMP0148)
+    cmake_policy(SET CMP0148 NEW)
+  endif()
+  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 endif()
 
-if(BUILD_PANGOLIN_PYTHON AND Python_FOUND)
+if(BUILD_PANGOLIN_PYTHON AND Python3_FOUND)
     # If we've inited the submodule, use that
     if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/pybind11/CMakeLists.txt")
         add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/pybind11)
@@ -15,7 +18,7 @@ if(BUILD_PANGOLIN_PYTHON AND Python_FOUND)
     endif()
 endif()
 
-if(BUILD_PANGOLIN_PYTHON AND Python_FOUND AND pybind11_FOUND)
+if(BUILD_PANGOLIN_PYTHON AND Python3_FOUND AND pybind11_FOUND)
     set(SRC_BINDINGS
         ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/attach.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/pypangolin/colour.cpp

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -159,7 +159,7 @@ elif [[ "$MANAGER" == "brew" ]]; then
     PKGS_OPTIONS+=(install)
     if ((VERBOSE > 0)); then PKGS_OPTIONS+=(--verbose); fi
     PKGS_REQUIRED+=(glew eigen cmake ninja)
-    PKGS_RECOMMENDED+=(libjpeg-turbo libpng openexr libtiff ffmpeg lz4 zstd catch2)
+    PKGS_RECOMMENDED+=(libjpeg-turbo libpng openexr libtiff ffmpeg lz4 zstd catch2 python-setuptools)
     # Brew doesn't have a dryrun option
     if ((DRYRUN > 0));  then
         MANAGER="echo $MANAGER"


### PR DESCRIPTION
Previously, an invalid wheel file is created when `setuptools` is not available. This can be difficult for users to debug.

Fix this by adding an explicit check for the `setuptools` module and fail when it is not available. Additionally, provide some information about the module search paths for debugging.