### PR TITLE
show errors and check exit code for wheel filename formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     - name: "(vcpkg only) install setuptools"
       if: ${{ matrix.package_manager == 'vcpkg' }}
       run: |
-        pip install setuptools
+        pip install setuptools wheel
 
     - name: Configure CMake
       run: >

--- a/cmake/MakePythonWheel.cmake
+++ b/cmake/MakePythonWheel.cmake
@@ -46,8 +46,12 @@ print(wheel_name(name='${python_module}', version='${version}', ext_modules=[Ext
 "
         OUTPUT_VARIABLE wheel_filename
         OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
+        RESULT_VARIABLE has_wheel_filename
     )
+
+    if(NOT has_wheel_filename EQUAL "0")
+        message(FATAL_ERROR "Cannot format wheel filename via 'setuptools'.")
+    endif()
 
     set(wheel_filename "${CMAKE_BINARY_DIR}/${wheel_filename}.whl")
     set(wheel_distinfo "${CMAKE_BINARY_DIR}/${python_module}-${version}.dist-info")

--- a/cmake/MakePythonWheel.cmake
+++ b/cmake/MakePythonWheel.cmake
@@ -28,6 +28,23 @@ except ImportError as e:
 
     execute_process(
         COMMAND ${Python3_EXECUTABLE} -c "
+import sys
+try:
+    from wheel.bdist_wheel import bdist_wheel
+    sys.exit(0)
+except ImportError as e:
+    print(f'{e}. Search paths:', file=sys.stderr)
+    for p in sys.path: print(f'  {p}', file=sys.stderr)
+    sys.exit(1)
+"
+    RESULT_VARIABLE has_bdist_wheel)
+
+    if(has_bdist_wheel EQUAL "1")
+        message(FATAL_ERROR "Python module `wheel.bdist_wheel` required for correct wheel filename generation.")
+    endif()
+
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -c "
 from setuptools.dist import Distribution
 from setuptools import Extension
 


### PR DESCRIPTION
Even with `setuptools` installed, the `bdist_wheel` snippet could still silently fail with an empty wheel filename. Fix this by showing the error and checking the exit code. Also, test for `bdist_wheel` and inform the user.

Fixes #959.