### PR TITLE
release wheel file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,14 @@ jobs:
       run: |
         cmake --build build --target test
 
+    - name: upload wheel file
+      if: ${{ matrix.shared_libs == 'OFF' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: pypangolin_wheel_${{ matrix.os }}
+        if-no-files-found: error
+        path: ./build/pypangolin-*.whl
+
   emscripten:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,3 +167,21 @@ jobs:
         build_dir: ../www
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    needs: build
+    if: contains(needs.*.result, 'success') && contains(github.ref, '/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: download artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pypangolin_wheel_*
+          merge-multiple: true
+          path: ./
+
+      - name: create release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: pypangolin-*.whl
+          artifactErrorsFailBuild: true


### PR DESCRIPTION
Based on https://github.com/stevenlovegrove/Pangolin/pull/969, this uploads the wheel file, that is built inside the CI, to the release page once a tag is pushed.

The wheel file only includes the Pangolin libraries and not any of the dependencies. Hence, users will still have to install dependencies manually via:
```sh
./scripts/install_prerequisites.sh all
```

Fixes #925, Fixes #968