### PR TITLE
manage "uninitialized" warnings

### DIFF
--- a/.github/workflows/colcon-workspace.yml
+++ b/.github/workflows/colcon-workspace.yml
@@ -34,14 +34,14 @@ jobs:
 
       - name: ROS 1 CI Action
         if: ${{ matrix.ros_version == 1 }}
-        uses: ros-tooling/action-ros-ci@v0.3
+        uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: pangolin
           target-ros1-distro: ${{ matrix.ros_distribution }}
 
       - name: ROS 2 CI Action
         if: ${{ matrix.ros_version == 2 }}
-        uses: ros-tooling/action-ros-ci@v0.3
+        uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: pangolin
           target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,9 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wno-parentheses)
     add_compile_options(-Wno-null-pointer-arithmetic)
     add_compile_options(-Wno-null-pointer-subtraction)
+    if(CMAKE_COMPILER_IS_GNUCC)
+        add_compile_options(-Werror=maybe-uninitialized)
+    endif()
 endif()
 
 #######################################################

--- a/components/pango_python/CMakeLists.txt
+++ b/components/pango_python/CMakeLists.txt
@@ -72,8 +72,11 @@ if(BUILD_PANGOLIN_PYTHON AND Python3_FOUND AND pybind11_FOUND)
     )
 
     if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-        # ignore "maybe-uninitialized" for Eigen
-        target_compile_options(${COMPONENT} PRIVATE "-Wno-uninitialized")
+        # ignore "maybe-uninitialized" and "maybe-uninitialized" for Eigen
+        if(CMAKE_COMPILER_IS_GNUCC)
+            target_compile_options(${COMPONENT} PRIVATE  "-Wno-error=maybe-uninitialized")
+        endif()
+        target_compile_options(${COMPONENT} PRIVATE  "-Wno-error=uninitialized")
     endif()
 
     PangolinRegisterFactory( InterpreterInterface PyInterpreter )

--- a/components/tinyobj/include/tinyobj/tiny_obj_loader.h
+++ b/components/tinyobj/include/tinyobj/tiny_obj_loader.h
@@ -433,7 +433,7 @@ struct vertex_index_t {
 struct face_t {
   unsigned int
       smoothing_group_id;  // smoothing group id. 0 = smoothing groupd is off.
-  int pad_;
+  int pad_ = 0;
   std::vector<vertex_index_t> vertex_indices;  // face vertex indices.
 
   face_t() : smoothing_group_id(0) {}


### PR DESCRIPTION
This fixes an `maybe-uninitialized` warning/error in `struct face_t` that is reported with g++ 14.

Fixes https://github.com/stevenlovegrove/Pangolin/issues/975.