### PR TITLE
Fix for variable length array initialization error.

### DIFF
--- a/components/pango_display/src/view.cpp
+++ b/components/pango_display/src/view.cpp
@@ -312,7 +312,8 @@ GLfloat View::GetClosestDepth([[maybe_unused]] int x, [[maybe_unused]] int y, in
 #endif
 
     const int zsize = zl*zl;
-    GLfloat zs[zsize];
+    std::vector<GLfloat> zsVec(zsize);
+    GLfloat* zs = zsVec.data();
 
 #ifndef HAVE_GLES
     glReadBuffer(GL_FRONT);


### PR DESCRIPTION
This PR addresses the following issue:

On Mac-ARM64 computer when building from source, I got the following errors: 
```
/tmp/Pangolin/components/pango_display/src/view.cpp:315:16: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  315 |     GLfloat zs[zsize];
      |                ^~~~~
/tmp/Pangolin/components/pango_display/src/view.cpp:315:16: note: initializer of 'zsize' is not a constant expression
/tmp/Pangolin/components/pango_display/src/view.cpp:314:15: note: declared here
  314 |     const int zsize = zl*zl;
      |               ^
1 error generated.
```
This is caused by compiler not allowing creation of variable length array. 

This PR addresses this by creating a pointer that points to the data member of a std::vector. 