### PR TITLE
fix compilation with CLang

### DIFF
--- a/components/pango_windowing/src/display_x11.cpp
+++ b/components/pango_windowing/src/display_x11.cpp
@@ -431,8 +431,8 @@ void X11Window::ProcessEvents()
         {
             const int button = ev.xbutton.button-1;
             MouseSignal(MouseEvent{
-               (float)ev.xbutton.x, (float)ev.xbutton.y,
-               GetEventFlagsFromXState(ev.xkey.state),
+               WindowInputEvent{(float)ev.xbutton.x, (float)ev.xbutton.y,
+                    GetEventFlagsFromXState(ev.xkey.state)},
                button, ev.xbutton.type == ButtonPress
            });
            break;
@@ -499,8 +499,8 @@ void X11Window::ProcessEvents()
 
             if(key >=0) {
                 KeyboardSignal(KeyboardEvent{
-                    (float)ev.xkey.x, (float)ev.xkey.y,
-                    GetEventFlagsFromXState(ev.xkey.state),
+                    WindowInputEvent{(float)ev.xkey.x, (float)ev.xkey.y,
+                        GetEventFlagsFromXState(ev.xkey.state)},
                     (unsigned char)key, ev.type == KeyPress
                 });
             }


### PR DESCRIPTION
When compiling with CLang the compilation stopped with a warning about "suggesting braces".

The current PR fixes this problem, I tested with CLang++ 14/18/20 and g++ 9/11/13.